### PR TITLE
Fix update command for curl-installed Orca

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,9 @@ base_url = "https://api.deepseek.com"
 
 ### Updates
 
-When `update_check` is enabled, Orca checks GitHub Releases before opening the interactive TUI. If a newer release is available, Orca shows a startup prompt with `Update now`, `Skip`, and `Skip until next version`. Choosing `Update now` runs the npm upgrade command and exits; choosing either skip option continues into the TUI.
+When `update_check` is enabled, Orca checks for a newer release before opening the interactive TUI. If a newer release is available, Orca shows a startup prompt with `Update now`, `Skip`, and `Skip until next version`. Choosing `Update now` updates the currently running install: npm-managed launches run the npm upgrade command, while direct binary launches rerun the curl installer into the current executable's directory. Choosing either skip option continues into the TUI.
+
+If you installed with curl and later switch to npm, make sure the npm global bin directory appears before `~/.local/bin` on `PATH`, or remove the older curl-installed `~/.local/bin/orca`. Otherwise your shell may keep running the curl-installed binary.
 
 Disable the startup check with:
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -46,6 +46,93 @@ enum UpdatePromptChoice {
     Quit,
 }
 
+#[derive(Clone, Debug, Eq, PartialEq)]
+enum UpdateAction {
+    NpmGlobalLatest,
+    StandaloneInstaller { install_dir: Option<PathBuf> },
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+struct UpdateCommand {
+    program: &'static str,
+    args: Vec<String>,
+    display: String,
+}
+
+impl UpdateAction {
+    fn command(&self) -> UpdateCommand {
+        match self {
+            Self::NpmGlobalLatest => UpdateCommand {
+                program: "npm",
+                args: vec![
+                    "install".to_string(),
+                    "-g".to_string(),
+                    "@blade-ai/orca@latest".to_string(),
+                    "--registry".to_string(),
+                    "https://registry.npmjs.org".to_string(),
+                ],
+                display:
+                    "npm install -g @blade-ai/orca@latest --registry https://registry.npmjs.org"
+                        .to_string(),
+            },
+            Self::StandaloneInstaller { install_dir } => {
+                standalone_update_command(install_dir.clone())
+            }
+        }
+    }
+
+    fn command_display(&self) -> String {
+        self.command().display
+    }
+}
+
+fn current_update_action() -> UpdateAction {
+    let current_exe = env::current_exe().ok();
+    update_action_from_env_and_exe(|name| env::var_os(name), current_exe.as_deref())
+}
+
+fn update_action_from_env_and_exe(
+    get_env: impl Fn(&str) -> Option<std::ffi::OsString>,
+    current_exe: Option<&Path>,
+) -> UpdateAction {
+    if get_env("ORCA_MANAGED_BY_NPM").is_some() {
+        UpdateAction::NpmGlobalLatest
+    } else {
+        UpdateAction::StandaloneInstaller {
+            install_dir: current_exe.and_then(|path| path.parent().map(Path::to_path_buf)),
+        }
+    }
+}
+
+fn standalone_update_command(install_dir: Option<PathBuf>) -> UpdateCommand {
+    let script = if install_dir.is_some() {
+        "tmp=$(mktemp) && trap 'rm -f \"$tmp\"' EXIT INT TERM && curl -fsSL https://orcaagent.dev/install.sh -o \"$tmp\" && ORCA_NON_INTERACTIVE=1 INSTALL_DIR=\"$1\" sh \"$tmp\""
+    } else {
+        "tmp=$(mktemp) && trap 'rm -f \"$tmp\"' EXIT INT TERM && curl -fsSL https://orcaagent.dev/install.sh -o \"$tmp\" && ORCA_NON_INTERACTIVE=1 sh \"$tmp\""
+    };
+    let mut args = vec![
+        "-c".to_string(),
+        script.to_string(),
+        "orca-update".to_string(),
+    ];
+    let display = if let Some(install_dir) = install_dir {
+        args.push(install_dir.display().to_string());
+        format!(
+            "curl -fsSL https://orcaagent.dev/install.sh -o <tmp> && ORCA_NON_INTERACTIVE=1 INSTALL_DIR={} sh <tmp>",
+            install_dir.display()
+        )
+    } else {
+        "curl -fsSL https://orcaagent.dev/install.sh -o <tmp> && ORCA_NON_INTERACTIVE=1 sh <tmp>"
+            .to_string()
+    };
+
+    UpdateCommand {
+        program: "sh",
+        args,
+        display,
+    }
+}
+
 impl UpdatePromptChoice {
     fn next(self) -> Self {
         match self {
@@ -1468,11 +1555,12 @@ fn render_update_prompt(
     )?;
     write!(stdout, "Release notes: {}\r\n", info.url)?;
     write!(stdout, "\r\n")?;
+    let update_command = upgrade_command_display();
     write_update_choice_row(
         stdout,
         1,
         "Update now",
-        Some(upgrade_command_display()),
+        Some(update_command.as_str()),
         highlighted == UpdatePromptChoice::UpdateNow,
     )?;
     write_update_choice_row(
@@ -1517,20 +1605,16 @@ impl Drop for RawModeGuard {
     }
 }
 
-fn upgrade_command_display() -> &'static str {
-    "npm install -g @blade-ai/orca@latest --registry https://registry.npmjs.org"
+fn upgrade_command_display() -> String {
+    current_update_action().command_display()
 }
 
 fn run_upgrade_command() -> i32 {
-    println!("Updating Orca...");
-    let status = match ProcessCommand::new("npm")
-        .args([
-            "install",
-            "-g",
-            "@blade-ai/orca@latest",
-            "--registry",
-            "https://registry.npmjs.org",
-        ])
+    let action = current_update_action();
+    println!("Updating Orca via `{}`...", action.command_display());
+    let command = action.command();
+    let status = match ProcessCommand::new(command.program)
+        .args(&command.args)
         .status()
     {
         Ok(status) => status,
@@ -1677,6 +1761,54 @@ mod tests {
         assert_eq!(
             UpdatePromptChoice::UpdateNow.prev(),
             UpdatePromptChoice::SkipUntilNext
+        );
+    }
+
+    #[test]
+    fn update_action_uses_npm_when_launched_from_npm_wrapper() {
+        let action = update_action_from_env_and_exe(
+            |name| match name {
+                "ORCA_MANAGED_BY_NPM" => Some("1".into()),
+                _ => None,
+            },
+            Some(Path::new("/custom/bin/orca")),
+        );
+
+        assert_eq!(
+            action.command_display(),
+            "npm install -g @blade-ai/orca@latest --registry https://registry.npmjs.org"
+        );
+    }
+
+    #[test]
+    fn update_action_reruns_standalone_installer_for_current_executable_dir() {
+        let action = update_action_from_env_and_exe(|_| None, Some(Path::new("/custom/bin/orca")));
+
+        assert_eq!(
+            action.command_display(),
+            "curl -fsSL https://orcaagent.dev/install.sh -o <tmp> && ORCA_NON_INTERACTIVE=1 INSTALL_DIR=/custom/bin sh <tmp>"
+        );
+    }
+
+    #[test]
+    fn standalone_update_command_downloads_before_running_installer() {
+        let action = update_action_from_env_and_exe(|_| None, Some(Path::new("/custom/bin/orca")));
+        let command = action.command();
+
+        assert_eq!(command.program, "sh");
+        assert!(command.args.iter().any(|arg| arg.contains("mktemp")));
+        assert!(
+            command
+                .args
+                .iter()
+                .any(|arg| arg.contains("curl -fsSL https://orcaagent.dev/install.sh -o \"$tmp\""))
+        );
+        assert!(command.args.iter().any(|arg| arg.contains("&& ORCA_NON_INTERACTIVE=1 INSTALL_DIR=\"$1\" sh \"$tmp\"")));
+        assert!(
+            !command
+                .args
+                .iter()
+                .any(|arg| arg.contains("| ORCA_NON_INTERACTIVE"))
         );
     }
 }


### PR DESCRIPTION
## Summary
- choose the TUI update command based on the active install method instead of always running npm
- rerun the curl installer for direct-binary launches, targeting the current executable directory
- download the installer to a temp file before executing it so curl failures do not look successful
- document PATH behavior when switching from curl installs to npm installs

## Verification
- rustfmt --edition 2024 --check src/cli.rs
- cargo test --bin orca
- cargo test -p orca-runtime update_check
- cargo check --bin orca
- git diff --check

Note: full cargo fmt --check still reports unrelated pre-existing formatting drift outside this change (crates/orca-runtime/src/update_check.rs and crates/orca-tui files), so I checked the touched Rust file directly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated README to clarify update behavior for npm-managed and curl-installed binaries
  * Added migration guidance for users switching from curl to npm installations

* **Bug Fixes**
  * Improved update flow to properly support multiple installation methods

<!-- end of auto-generated comment: release notes by coderabbit.ai -->