### PR TITLE
docs(site): add official community links

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,11 @@ curl -fsSL https://orcaagent.dev/install.sh | \
 
 Download the archive for your platform from the latest GitHub Release, extract it, and place `orca` on your `PATH`.
 
+## Community
+
+- QQ group: `472309526`
+- Telegram: https://t.me/+11No1w5ZbTMyZTQ1
+
 ## Quick Start
 
 ```sh

--- a/site/scripts/check-seo.mjs
+++ b/site/scripts/check-seo.mjs
@@ -3,6 +3,9 @@ import { readFileSync } from "node:fs";
 const root = new URL("..", import.meta.url);
 const canonicalUrl = "https://orcaagent.dev/";
 const indexHtml = readFileSync(new URL("index.html", root), "utf8");
+const appSource = readFileSync(new URL("src/App.tsx", root), "utf8");
+const styles = readFileSync(new URL("src/styles.css", root), "utf8");
+const readme = readFileSync(new URL("../README.md", root), "utf8");
 const robotsTxt = readFileSync(new URL("public/robots.txt", root), "utf8");
 const sitemapXml = readFileSync(new URL("public/sitemap.xml", root), "utf8");
 const socialPng = readFileSync(new URL("public/orca-social.png", root));
@@ -50,6 +53,21 @@ check(sitemapXml.includes("<lastmod>2026-06-22</lastmod>"), "sitemap.xml missing
 check(socialPng.subarray(1, 4).toString("ascii") === "PNG", "Social image is not a PNG");
 check(socialPng.readUInt32BE(16) === 1200, "Social PNG width must be 1200px");
 check(socialPng.readUInt32BE(20) === 630, "Social PNG height must be 630px");
+
+check(appSource.includes("472309526"), "Homepage missing official QQ group");
+check(
+  appSource.includes("https://t.me/+11No1w5ZbTMyZTQ1"),
+  "Homepage missing official Telegram group",
+);
+check(readme.includes("472309526"), "README missing official QQ group");
+check(
+  readme.includes("https://t.me/+11No1w5ZbTMyZTQ1"),
+  "README missing official Telegram group",
+);
+check(
+  /\.hero-copy\s*\{[^}]*align-self:\s*start;/s.test(styles),
+  "Hero copy must stay top-aligned while the terminal animation grows",
+);
 
 const jsonLdBlocks = [
   ...indexHtml.matchAll(

--- a/site/src/App.tsx
+++ b/site/src/App.tsx
@@ -15,6 +15,7 @@ const links = {
   github: "https://github.com/echoVic/blade-deepseek",
   npm: "https://www.npmjs.com/package/@blade-ai/orca",
   releases: "https://github.com/echoVic/blade-deepseek/releases/latest",
+  telegram: "https://t.me/+11No1w5ZbTMyZTQ1",
 };
 
 type Locale = "en" | "zh";
@@ -175,6 +176,10 @@ const copy = {
         "Supported platforms: macOS arm64/x64 and Linux arm64/x64. Downloads are available on",
       releases: "GitHub Releases",
     },
+    community: {
+      qq: "QQ Group 472309526",
+      telegram: "Telegram",
+    },
     tui: {
       user: "fix the failing auth test",
       reasoning: "reasoning",
@@ -320,6 +325,10 @@ const copy = {
       failed: "复制失败",
       platforms: "支持平台：macOS arm64/x64 和 Linux arm64/x64。下载文件位于",
       releases: "GitHub Releases",
+    },
+    community: {
+      qq: "QQ 群 472309526",
+      telegram: "Telegram",
     },
     tui: {
       user: "修复失败的 auth 测试",
@@ -1149,6 +1158,10 @@ function App() {
           </a>
           <a href={links.releases} rel="noreferrer">
             {t.install.releases}
+          </a>
+          <span>{t.community.qq}</span>
+          <a href={links.telegram} rel="noreferrer">
+            {t.community.telegram}
           </a>
         </div>
       </footer>

--- a/site/src/styles.css
+++ b/site/src/styles.css
@@ -286,6 +286,10 @@ h3 {
   min-width: 0;
 }
 
+.hero-copy {
+  align-self: start;
+}
+
 .subtitle {
   max-width: 56ch;
   margin-bottom: 22px;
@@ -1028,6 +1032,10 @@ footer .foot-brand .brand-mark {
 footer div.links {
   display: flex;
   gap: 18px;
+}
+
+footer div.links span {
+  color: var(--muted);
 }
 
 footer a:hover {


### PR DESCRIPTION
## Summary
- add official QQ and Telegram community links to README and the homepage footer
- keep the hero copy top-aligned while the terminal animation grows
- extend the site check to guard community links and hero alignment

## Tests
- npm run check:seo
- npm run build
- git diff --check

Note: baseline cargo test had pre-existing workflow_cli_contract failures before this docs/site change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added community support section with QQ group and Telegram links to documentation and website footer in both English and Chinese locales.
  * Updated styling for improved hero copy alignment and footer link presentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->