### PR TITLE
fix(test): make subagent sleep hook portable on Windows

### DIFF
--- a/tests/subagent_contract.rs
+++ b/tests/subagent_contract.rs
@@ -519,9 +519,13 @@ fn find_event<'a>(events: &'a [Value], event_type: &str) -> &'a Value {
 }
 
 fn subagent_cli_test_guard() -> MutexGuard<'static, ()> {
+    // Recover from a poisoned lock so that a single failing test is reported on
+    // its own merits instead of cascading into every other test failing with
+    // `PoisonError`. The guard only serializes access; there is no shared state
+    // to be left inconsistent by a panicking test.
     SUBAGENT_CLI_TEST_LOCK
         .lock()
-        .expect("subagent CLI test lock")
+        .unwrap_or_else(std::sync::PoisonError::into_inner)
 }
 
 fn run_git(cwd: &std::path::Path, args: &[&str]) {
@@ -640,9 +644,16 @@ fn poll_subagent_status(
 
 fn write_sleep_hook_config(home: &std::path::Path, seconds: f32) {
     std::fs::create_dir_all(home).expect("create ORCA_HOME");
+    // The resolved host shell differs per platform, so the delay command has to
+    // match its dialect. Unix runs the config through `sh -c`, while Windows
+    // resolves to PowerShell, where `sleep` is not a valid command.
+    #[cfg(unix)]
+    let sleep_command = format!("sleep {seconds}");
+    #[cfg(windows)]
+    let sleep_command = format!("Start-Sleep -Milliseconds {}", (seconds * 1000.0).round() as u64);
     std::fs::write(
         home.join("config.toml"),
-        format!("[[hooks]]\nevent = \"pre_model_call\"\ncommand = \"sleep {seconds}\"\n"),
+        format!("[[hooks]]\nevent = \"pre_model_call\"\ncommand = \"{sleep_command}\"\n"),
     )
     .expect("write hook config");
 }


### PR DESCRIPTION
## Problem

The Windows CI gate on `main` has been failing on the `subagent_contract` test binary (all 12 tests reported failed, e.g. run [30501966908](https://github.com/echoVic/blade-deepseek/actions/runs/30501966908)).

## Root cause

`async_subagent_completes_after_launching_exec_process_exits` writes a `pre_model_call` hook that runs `sleep 0.4`:

- On Windows the resolved host shell is PowerShell (`pwsh`/`powershell.exe`), where `sleep` is an alias for `Start-Sleep`.
- Windows PowerShell 5.1's `Start-Sleep` rejects the **fractional** `0.4` seconds argument (only PowerShell 6.2+ accepts a `double`), and `cmd.exe` has no `sleep` at all.
- The hook therefore fails → `orca exec` exits `1` instead of `0` → the test panics (`left: Some(1), right: Some(0)`).

Because every test in the file shares one `static Mutex`, that first panic **poisons the lock**, cascading into all other tests failing with `PoisonError` and masking the real cause. (Evidence: the suite "finished in 1.70s", proving the 0.4s hook never actually slept.)

## Fix

1. **Portable hook command** — emit `sleep {seconds}` on Unix and `Start-Sleep -Milliseconds {ms}` (integer, valid on both PowerShell 5.1 and 7) on Windows, mirroring the existing `#[cfg(unix)]`/`#[cfg(windows)]` hook idiom in `tests/exec_jsonl.rs`.
2. **Poison resilience** — recover from a poisoned test lock so a single failure is reported on its own merits instead of cascading across the suite.

## Verification

- `cargo test --test subagent_contract` → 12/12 pass on macOS (host).
- The `#[cfg(windows)]` branch was compiled in isolation and produces `Start-Sleep -Milliseconds 400`.
- Full cross-compile to `x86_64-pc-windows-msvc` is blocked locally by `ring`'s C toolchain requirement (no Windows C headers on this Mac); the Windows CI gate on this PR is the authoritative check.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved test reliability by recovering from locking errors instead of failing immediately.
  * Updated generated hook commands to use platform-appropriate sleep syntax on Unix and Windows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->