### PR TITLE
fix(sandbox): close metadata permission escape paths from Seatbelt review

### DIFF
--- a/crates/orca-provider/src/lib.rs
+++ b/crates/orca-provider/src/lib.rs
@@ -901,9 +901,21 @@ fn mock_call(conversation: &Conversation) -> ProviderResponse {
         };
     }
 
-    if let Some(command) = prompt.trim().strip_prefix("force_bash ") {
+    if !has_tool_results && let Some(command) = prompt.trim().strip_prefix("force_bash ") {
+        let tool_id = (1_u64..)
+            .map(|index| format!("mock-tool-{index}"))
+            .find(|candidate| {
+                !conversation.messages.iter().any(|message| match message {
+                    Message::Assistant { tool_calls, .. } => tool_calls
+                        .iter()
+                        .any(|tool_call| tool_call.id == *candidate),
+                    Message::Tool { tool_call_id, .. } => tool_call_id == candidate,
+                    Message::System { .. } | Message::User { .. } => false,
+                })
+            })
+            .expect("mock tool id space is not exhausted");
         let bash = ToolRequest {
-            id: "mock-tool-1".to_string(),
+            id: tool_id,
             name: ToolName::Bash,
             action: ActionKind::Shell,
             target: Some(command.to_string()),
@@ -1902,6 +1914,32 @@ mod tests {
                 ProviderStep::ToolCall(second)
             ] if first.name == ToolName::RequestPermissions && second.name == ToolName::Bash
         ));
+    }
+
+    #[test]
+    fn mock_force_bash_uses_fresh_tool_ids_across_turns_and_stops_after_result() {
+        let mut conversation = Conversation::new();
+        conversation.add_user("force_bash printf first".to_string());
+        let first = mock_call(&conversation);
+        let first_call = first.tool_calls.first().unwrap().clone();
+        assert_eq!(first_call.id, "mock-tool-1");
+        conversation.add_assistant(None, None, vec![first_call.clone()]);
+        conversation.add_tool_result(first_call.id, "first".to_string());
+        conversation.add_assistant(Some("first done".to_string()), None, Vec::new());
+        conversation.add_user("force_bash printf second".to_string());
+
+        let second = mock_call(&conversation);
+        let second_call = second.tool_calls.first().unwrap().clone();
+        assert_eq!(second_call.id, "mock-tool-2");
+        conversation.add_assistant(None, None, vec![second_call.clone()]);
+        conversation.add_tool_result(second_call.id, "second".to_string());
+
+        let completed = mock_call(&conversation);
+        assert!(completed.tool_calls.is_empty());
+        assert_eq!(
+            completed.assistant_content.as_deref(),
+            Some("Mock completed after tool execution.")
+        );
     }
 
     #[test]

--- a/crates/orca-runtime/src/runtime_bash.rs
+++ b/crates/orca-runtime/src/runtime_bash.rs
@@ -106,6 +106,26 @@ pub(crate) fn execute_bash_with_shell_session(
         Ok(sandbox) => sandbox,
         Err(error) => return ToolResult::failed(request, error, None),
     };
+    let mut ordinary_additional_roots = Vec::new();
+    for directory in &config.additional_working_directories {
+        if directory.source == crate::runtime_permission::SESSION_METADATA_DIRECTORY_SOURCE {
+            if orca_tools::sandbox::is_safe_metadata_writable_root(&directory.path) {
+                push_unique_path(&mut sandbox.metadata_writable_roots, directory.path.clone());
+            }
+            continue;
+        }
+        if !orca_tools::sandbox::is_protected_metadata_root(&directory.path) {
+            push_unique_path(&mut ordinary_additional_roots, directory.path.clone());
+        }
+    }
+    for root in additional_roots {
+        // Protected metadata paths only gain write authority through the
+        // dedicated overlay/session channel below. Their presence in ordinary
+        // runtime settings must not mint an escalation by path shape alone.
+        if !orca_tools::sandbox::is_protected_metadata_root(root) {
+            push_unique_path(&mut ordinary_additional_roots, root.clone());
+        }
+    }
     for (domain, access) in permission_overlay.network_domain_permissions() {
         match access {
             PermissionProfileNetworkAccess::Deny => {
@@ -130,7 +150,7 @@ pub(crate) fn execute_bash_with_shell_session(
     let result = execute_bash_with_sandbox(RuntimeBashSandboxContext {
         command,
         cwd,
-        additional_roots,
+        additional_roots: &ordinary_additional_roots,
         sandbox: &sandbox,
         shell_timeout_secs,
         task_registry,
@@ -167,7 +187,7 @@ pub(crate) fn execute_bash_with_shell_session(
         return execute_bash_with_sandbox(RuntimeBashSandboxContext {
             command,
             cwd,
-            additional_roots,
+            additional_roots: &ordinary_additional_roots,
             sandbox: &retry_sandbox,
             shell_timeout_secs,
             task_registry,
@@ -210,7 +230,7 @@ pub(crate) fn execute_bash_with_shell_session(
             return execute_bash_with_sandbox(RuntimeBashSandboxContext {
                 command,
                 cwd,
-                additional_roots,
+                additional_roots: &ordinary_additional_roots,
                 sandbox: &retry_sandbox,
                 shell_timeout_secs,
                 task_registry,
@@ -245,13 +265,31 @@ pub(crate) fn execute_bash_with_shell_session(
                     shell_timeout_secs,
                 );
             }
+
+            return execute_bash_once(RuntimeBashOnceContext {
+                command,
+                cwd,
+                additional_readable_directories: Vec::new(),
+                additional_working_directories: ordinary_additional_roots,
+                metadata_writable_directories: Vec::new(),
+                denied_working_directories: Vec::new(),
+                allowed_unix_socket_roots: Vec::new(),
+                env: Default::default(),
+                sandbox: ShellSandboxMode::DangerFullAccess,
+                shell_timeout_secs,
+                task_registry,
+                cancel,
+                output_handler: reborrow_output_handler(&mut output_handler),
+            })
+            .with_sandbox_diagnostic(cwd)
+            .into_tool_result(request, output_truncation, shell_timeout_secs);
         }
 
         return execute_bash_once(RuntimeBashOnceContext {
             command,
             cwd,
             additional_readable_directories: Vec::new(),
-            additional_working_directories: additional_roots.to_vec(),
+            additional_working_directories: ordinary_additional_roots,
             metadata_writable_directories: Vec::new(),
             denied_working_directories: Vec::new(),
             allowed_unix_socket_roots: Vec::new(),

--- a/crates/orca-runtime/src/runtime_host.rs
+++ b/crates/orca-runtime/src/runtime_host.rs
@@ -2205,7 +2205,10 @@ pub struct RuntimeThreadStartRequest {
 }
 
 impl RuntimeThreadStartRequest {
-    pub fn new(config: RunConfig, title: impl Into<String>) -> Self {
+    pub fn new(mut config: RunConfig, title: impl Into<String>) -> Self {
+        config.additional_working_directories.retain(|directory| {
+            directory.source != crate::runtime_permission::SESSION_METADATA_DIRECTORY_SOURCE
+        });
         Self {
             config,
             title: title.into(),

--- a/crates/orca-runtime/src/runtime_permission.rs
+++ b/crates/orca-runtime/src/runtime_permission.rs
@@ -10,6 +10,8 @@ use crate::protocol::{
     PermissionGrantScope, PermissionResponseDecision, RequestFileSystemPermissions,
     RequestNetworkPermissions, RequestPermissionProfile, RequestShellPermissions,
 };
+
+pub(crate) const SESSION_METADATA_DIRECTORY_SOURCE: &str = "session-metadata";
 use crate::sandbox_denial::{
     SandboxDenialDiagnostic, should_request_filesystem_permission_with_denied_roots,
 };
@@ -470,8 +472,10 @@ impl TurnPermissionOverlay {
                 if root.as_os_str().is_empty() {
                     continue;
                 }
-                if is_exact_metadata_root(root) {
-                    if !self.metadata_writable_directories.contains(root) {
+                if orca_tools::sandbox::is_protected_metadata_root(root) {
+                    if orca_tools::sandbox::is_safe_metadata_writable_root(root)
+                        && !self.metadata_writable_directories.contains(root)
+                    {
                         self.metadata_writable_directories.push(root.clone());
                     }
                 } else if !self.additional_working_directories.contains(root) {
@@ -488,13 +492,6 @@ impl TurnPermissionOverlay {
             self.unsandboxed_shell = true;
         }
     }
-}
-
-fn is_exact_metadata_root(path: &std::path::Path) -> bool {
-    matches!(
-        path.file_name().and_then(|name| name.to_str()),
-        Some(".git" | ".agents" | ".codex")
-    )
 }
 
 #[cfg(test)]
@@ -597,6 +594,28 @@ mod tests {
             overlay.additional_working_directories(),
             &[PathBuf::from("/repo"), PathBuf::from("/repo/.git/config"),]
         );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn approved_symlink_metadata_root_is_not_made_writable() {
+        let parent = tempfile::tempdir().unwrap();
+        let target = parent.path().join("outside");
+        let metadata_link = parent.path().join(".agents");
+        std::fs::create_dir(&target).unwrap();
+        std::os::unix::fs::symlink(&target, &metadata_link).unwrap();
+        let mut overlay = TurnPermissionOverlay::default();
+
+        overlay.merge_permissions(&RequestPermissionProfile {
+            file_system: Some(RequestFileSystemPermissions {
+                write: Some(vec![metadata_link]),
+                ..Default::default()
+            }),
+            ..Default::default()
+        });
+
+        assert!(overlay.metadata_writable_directories().is_empty());
+        assert!(overlay.additional_working_directories().is_empty());
     }
 
     #[test]

--- a/crates/orca-runtime/src/server.rs
+++ b/crates/orca-runtime/src/server.rs
@@ -266,12 +266,21 @@ fn apply_permission_updates(config: &mut RunConfig, updates: Vec<PermissionUpdat
             }),
             PermissionUpdate::AddDirectories { directories } => {
                 for directory in directories {
+                    if directory.source
+                        == crate::runtime_permission::SESSION_METADATA_DIRECTORY_SOURCE
+                    {
+                        continue;
+                    }
                     if let Some(existing) = config
                         .additional_working_directories
                         .iter_mut()
                         .find(|existing| existing.path == directory.path)
                     {
-                        existing.source = directory.source;
+                        if existing.source
+                            != crate::runtime_permission::SESSION_METADATA_DIRECTORY_SOURCE
+                        {
+                            existing.source = directory.source;
+                        }
                     } else {
                         config.additional_working_directories.push(directory);
                     }
@@ -281,7 +290,8 @@ fn apply_permission_updates(config: &mut RunConfig, updates: Vec<PermissionUpdat
                 destination,
                 directories,
             } => config.additional_working_directories.retain(|directory| {
-                directory.source != destination
+                directory.source == crate::runtime_permission::SESSION_METADATA_DIRECTORY_SOURCE
+                    || directory.source != destination
                     || !directories.iter().any(|remove| remove == &directory.path)
             }),
         }
@@ -799,7 +809,9 @@ fn materialize_session_permission_grant(
     for root in roots {
         for root in materialize_workspace_roots_paths(&thread.cwd, runtime_workspace_roots, root) {
             if orca_tools::sandbox::is_protected_metadata_root(&root) {
-                push_unique_path(&mut thread.metadata_writable_directories, root);
+                if orca_tools::sandbox::is_safe_metadata_writable_root(&root) {
+                    push_unique_path(&mut thread.metadata_writable_directories, root);
+                }
             } else if !thread
                 .additional_working_directories
                 .iter()
@@ -1339,7 +1351,9 @@ fn run_command_exec<W: Write>(
                 requested,
             ) {
                 if orca_tools::sandbox::is_protected_metadata_root(&root) {
-                    push_unique_path(&mut metadata_writable_directories, root);
+                    if orca_tools::sandbox::is_safe_metadata_writable_root(&root) {
+                        push_unique_path(&mut metadata_writable_directories, root);
+                    }
                 } else {
                     push_unique_path(&mut additional_working_directories, root);
                 }

--- a/crates/orca-runtime/src/server/command_exec_sandbox.rs
+++ b/crates/orca-runtime/src/server/command_exec_sandbox.rs
@@ -569,7 +569,9 @@ fn push_writable_root(
     root: PathBuf,
 ) {
     if orca_tools::sandbox::is_protected_metadata_root(&root) {
-        push_unique_path(metadata_writable_roots, root);
+        if orca_tools::sandbox::is_safe_metadata_writable_root(&root) {
+            push_unique_path(metadata_writable_roots, root);
+        }
     } else {
         push_unique_path(additional_writable_roots, root);
     }

--- a/crates/orca-runtime/src/tool_router.rs
+++ b/crates/orca-runtime/src/tool_router.rs
@@ -329,6 +329,10 @@ impl<'a> RuntimeToolRouter<'a> {
                 let additional_roots = config
                     .additional_working_directories
                     .iter()
+                    .filter(|directory| {
+                        directory.source
+                            != crate::runtime_permission::SESSION_METADATA_DIRECTORY_SOURCE
+                    })
                     .map(|directory| directory.path.clone())
                     .chain(
                         permission_overlay

--- a/crates/orca-tools/src/external.rs
+++ b/crates/orca-tools/src/external.rs
@@ -368,7 +368,9 @@ mod tests {
             &request,
             dir.path(),
             ToolOutputTruncation::bytes(1024),
-            Duration::from_millis(200),
+            // Leave enough startup budget for a loaded serial workspace run to
+            // install the TERM trap. This test checks exit-code preservation.
+            Duration::from_secs(3),
         );
 
         assert_eq!(result.status, ToolStatus::Failed);

--- a/crates/orca-tools/src/sandbox/bwrap.rs
+++ b/crates/orca-tools/src/sandbox/bwrap.rs
@@ -29,6 +29,8 @@
 
 use std::path::{Path, PathBuf};
 
+use walkdir::WalkDir;
+
 /// How the sandboxed filesystem view is constructed.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum LinuxReadScope {
@@ -49,6 +51,14 @@ pub struct LinuxSandboxPolicy {
     pub allowed_unix_socket_roots: Vec<PathBuf>,
     /// Roots granted read-write access.
     pub writable_roots: Vec<PathBuf>,
+    /// Ordinary writable roots whose existing protected metadata descendants
+    /// must be discovered and re-bound read-only. This excludes implicit temp
+    /// roots, which would otherwise require an unbounded scan on every launch.
+    pub metadata_protection_roots: Vec<PathBuf>,
+    /// Protected metadata roots granted read-write access through the dedicated
+    /// escalation channel. Keeping provenance separate prevents an ordinary
+    /// writable-root grant from being mistaken for metadata authority.
+    pub metadata_writable_roots: Vec<PathBuf>,
     /// Roots that must stay read-only even when they fall under a writable
     /// root (re-bound with `--ro-bind` after the writable binds). Used to
     /// protect workspace metadata such as `.git` while preserving reads.
@@ -58,6 +68,67 @@ pub struct LinuxSandboxPolicy {
     pub denied_roots: Vec<PathBuf>,
     /// When false, the command runs in an isolated (empty) network namespace.
     pub network_access: bool,
+}
+
+pub(crate) fn effective_read_only_roots(policy: &LinuxSandboxPolicy) -> Vec<PathBuf> {
+    let mut roots = policy.read_only_roots.clone();
+    for writable_root in &policy.metadata_protection_roots {
+        if let Some(metadata) = writable_root
+            .ancestors()
+            .find(|path| crate::sandbox::is_protected_metadata_root(path))
+        {
+            let canonical = metadata
+                .canonicalize()
+                .unwrap_or_else(|_| metadata.to_path_buf());
+            if !is_explicit_metadata_writable_root(policy, metadata, &canonical) {
+                push_unique(&mut roots, canonical);
+            }
+        }
+
+        let mut entries = WalkDir::new(writable_root).follow_links(false).into_iter();
+        while let Some(entry) = entries.next() {
+            match entry {
+                Ok(entry) if crate::sandbox::is_protected_metadata_root(entry.path()) => {
+                    let canonical = entry
+                        .path()
+                        .canonicalize()
+                        .unwrap_or_else(|_| entry.path().to_path_buf());
+                    if !is_explicit_metadata_writable_root(policy, entry.path(), &canonical) {
+                        push_unique(&mut roots, canonical);
+                    }
+                    if entry.file_type().is_dir() {
+                        entries.skip_current_dir();
+                    }
+                }
+                Ok(_) => {}
+                Err(error) => {
+                    // A subtree that cannot be inspected must not silently
+                    // inherit a broader writable grant.
+                    let unreadable = error
+                        .path()
+                        .map(Path::to_path_buf)
+                        .unwrap_or_else(|| writable_root.clone());
+                    let canonical = unreadable
+                        .canonicalize()
+                        .unwrap_or_else(|_| unreadable.clone());
+                    push_unique(&mut roots, canonical);
+                }
+            }
+        }
+    }
+    roots
+}
+
+fn is_explicit_metadata_writable_root(
+    policy: &LinuxSandboxPolicy,
+    metadata: &Path,
+    canonical_metadata: &Path,
+) -> bool {
+    crate::sandbox::is_safe_metadata_writable_root(metadata)
+        && policy.metadata_writable_roots.iter().any(|root| {
+            let canonical = root.canonicalize().unwrap_or_else(|_| root.clone());
+            canonical == canonical_metadata
+        })
 }
 
 /// Build the full `bwrap` argument vector (excluding the leading `bwrap`
@@ -115,14 +186,21 @@ pub fn build_bwrap_argv(policy: &LinuxSandboxPolicy, command: &str) -> Vec<Strin
             argv.push(path_arg(root));
         }
     }
+    for root in &policy.metadata_writable_roots {
+        if root.exists() {
+            argv.push("--bind".to_string());
+            argv.push(path_arg(root));
+            argv.push(path_arg(root));
+        }
+    }
 
     // Re-assert read-only roots after writable binds so protected metadata
     // (e.g. `.git`) stays readable but not writable even under a writable root.
-    for root in &policy.read_only_roots {
+    for root in effective_read_only_roots(policy) {
         if root.exists() {
             argv.push("--ro-bind".to_string());
-            argv.push(path_arg(root));
-            argv.push(path_arg(root));
+            argv.push(path_arg(&root));
+            argv.push(path_arg(&root));
         }
     }
 
@@ -164,6 +242,9 @@ fn restricted_read_roots(policy: &LinuxSandboxPolicy) -> Vec<PathBuf> {
     for root in &policy.writable_roots {
         push_unique(&mut roots, root.clone());
     }
+    for root in &policy.metadata_writable_roots {
+        push_unique(&mut roots, root.clone());
+    }
     for root in crate::sandbox::linux_platform_default_read_roots() {
         push_unique(&mut roots, root);
     }
@@ -203,6 +284,8 @@ mod tests {
             readable_roots: Vec::new(),
             allowed_unix_socket_roots: Vec::new(),
             writable_roots: Vec::new(),
+            metadata_protection_roots: Vec::new(),
+            metadata_writable_roots: Vec::new(),
             read_only_roots: Vec::new(),
             denied_roots: Vec::new(),
             network_access: true,
@@ -283,6 +366,99 @@ mod tests {
                 "read-only rebind must come after writable bind: {joined}"
             );
         }
+    }
+
+    #[test]
+    fn ordinary_external_writable_root_rebinds_its_metadata_read_only() {
+        let external = tempfile::tempdir().unwrap();
+        let metadata = external.path().join(".git");
+        std::fs::create_dir(&metadata).unwrap();
+        let mut policy = base_policy();
+        policy.writable_roots = vec![external.path().to_path_buf()];
+        policy.metadata_protection_roots = policy.writable_roots.clone();
+
+        let argv = build_bwrap_argv(&policy, "true");
+        let metadata = path_arg(&metadata.canonicalize().unwrap());
+        let read_only_position = argv
+            .windows(3)
+            .position(|args| args == ["--ro-bind", metadata.as_str(), metadata.as_str()]);
+
+        assert!(read_only_position.is_some());
+    }
+
+    #[test]
+    fn ordinary_exact_metadata_writable_root_is_rebound_read_only() {
+        let external = tempfile::tempdir().unwrap();
+        let metadata = external.path().join(".git");
+        std::fs::create_dir(&metadata).unwrap();
+        let mut policy = base_policy();
+        policy.writable_roots = vec![metadata.clone()];
+        policy.metadata_protection_roots = policy.writable_roots.clone();
+
+        let argv = build_bwrap_argv(&policy, "true");
+        let metadata = path_arg(&metadata.canonicalize().unwrap());
+        let read_only_position = argv
+            .windows(3)
+            .position(|args| args == ["--ro-bind", metadata.as_str(), metadata.as_str()]);
+
+        assert!(read_only_position.is_some());
+    }
+
+    #[test]
+    fn ordinary_writable_root_rebinds_nested_metadata_read_only() {
+        let external = tempfile::tempdir().unwrap();
+        let metadata = external.path().join("project").join(".git");
+        std::fs::create_dir_all(&metadata).unwrap();
+        let mut policy = base_policy();
+        policy.writable_roots = vec![external.path().to_path_buf()];
+        policy.metadata_protection_roots = policy.writable_roots.clone();
+
+        let argv = build_bwrap_argv(&policy, "true");
+        let metadata = path_arg(&metadata.canonicalize().unwrap());
+        let read_only_position = argv
+            .windows(3)
+            .position(|args| args == ["--ro-bind", metadata.as_str(), metadata.as_str()]);
+
+        assert!(read_only_position.is_some());
+    }
+
+    #[test]
+    fn explicit_metadata_writable_root_is_not_rebound_read_only() {
+        let external = tempfile::tempdir().unwrap();
+        let metadata = external.path().join(".git");
+        std::fs::create_dir(&metadata).unwrap();
+        let mut policy = base_policy();
+        policy.writable_roots = vec![external.path().to_path_buf()];
+        policy.metadata_protection_roots = policy.writable_roots.clone();
+        policy.metadata_writable_roots = vec![metadata.clone()];
+
+        let argv = build_bwrap_argv(&policy, "true");
+        let metadata = path_arg(&metadata);
+        let read_only_position = argv
+            .windows(3)
+            .position(|args| args == ["--ro-bind", metadata.as_str(), metadata.as_str()]);
+
+        assert!(read_only_position.is_none());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn symlinked_metadata_does_not_treat_its_writable_target_as_an_explicit_grant() {
+        let external = tempfile::tempdir().unwrap();
+        let metadata = external.path().join(".git");
+        std::os::unix::fs::symlink(external.path(), &metadata).unwrap();
+        let mut policy = base_policy();
+        let target = external.path().canonicalize().unwrap();
+        policy.writable_roots = vec![target.clone()];
+        policy.metadata_protection_roots = policy.writable_roots.clone();
+
+        let argv = build_bwrap_argv(&policy, "true");
+        let target = path_arg(&target);
+        let read_only_position = argv
+            .windows(3)
+            .position(|args| args == ["--ro-bind", target.as_str(), target.as_str()]);
+
+        assert!(read_only_position.is_some());
     }
 
     #[test]

--- a/crates/orca-tools/src/sandbox/linux.rs
+++ b/crates/orca-tools/src/sandbox/linux.rs
@@ -22,7 +22,9 @@ use std::path::Path;
 use std::path::PathBuf;
 use std::process::Command;
 
-use crate::sandbox::bwrap::{LinuxReadScope, LinuxSandboxPolicy, build_bwrap_argv};
+use crate::sandbox::bwrap::{
+    LinuxReadScope, LinuxSandboxPolicy, build_bwrap_argv, effective_read_only_roots,
+};
 
 /// Resolved, canonicalized sandbox request shared by both backends.
 pub(crate) struct LinuxSandboxRequest {
@@ -66,15 +68,19 @@ pub(crate) fn sandbox_command(request: LinuxSandboxRequest) -> Command {
         return bwrap_command(bwrap, &request);
     }
 
-    // No bwrap: try the in-process Landlock + seccomp fallback.
     // Some nested deny/read-only policies require namespace mounts that
-    // Landlock cannot express. Only strict restricted-read requests must fail
-    // closed when no enforcing backend is available; non-strict capability
-    // modes retain their established compatibility fallback.
-    let must_fail_closed = request.strict;
+    // Landlock cannot express. They must fail before selecting the Landlock
+    // fallback, even when Landlock itself is available.
+    if policy_requires_bwrap(&request) {
+        return fail_closed_command("this Linux sandbox policy requires bubblewrap");
+    }
+
+    // No bwrap: try the in-process Landlock + seccomp fallback. Strict requests
+    // fail closed if that backend is unavailable; other capability modes retain
+    // their compatibility fallback.
     match landlock_command(&request) {
         Ok(command) => command,
-        Err(_) if must_fail_closed => {
+        Err(_) if request.strict => {
             fail_closed_command("no compatible Linux sandbox backend is available")
         }
         Err(_) => plain_command(&request.command, &request.policy.cwd),
@@ -86,14 +92,14 @@ fn policy_requires_bwrap(request: &LinuxSandboxRequest) -> bool {
     if !policy.network_access && !policy.allowed_unix_socket_roots.is_empty() {
         return true;
     }
-    let writable_overlap = policy
-        .read_only_roots
+    let writable_overlap = effective_read_only_roots(policy)
         .iter()
         .filter(|root| root.exists())
         .any(|read_only| {
             policy
                 .writable_roots
                 .iter()
+                .chain(&policy.metadata_writable_roots)
                 .any(|writable| paths_overlap(read_only, writable))
         });
     if writable_overlap {
@@ -115,6 +121,7 @@ fn policy_requires_bwrap(request: &LinuxSandboxRequest) -> bool {
     let mut accessible = vec![policy.cwd.as_path()];
     accessible.extend(policy.readable_roots.iter().map(PathBuf::as_path));
     accessible.extend(policy.writable_roots.iter().map(PathBuf::as_path));
+    accessible.extend(policy.metadata_writable_roots.iter().map(PathBuf::as_path));
     accessible.extend(
         policy
             .allowed_unix_socket_roots
@@ -270,6 +277,9 @@ mod linux_landlock {
             for root in &policy.writable_roots {
                 push_unique(&mut readable_roots, root.clone());
             }
+            for root in &policy.metadata_writable_roots {
+                push_unique(&mut readable_roots, root.clone());
+            }
             for root in &policy.allowed_unix_socket_roots {
                 push_unique(&mut readable_roots, root.clone());
             }
@@ -308,6 +318,7 @@ mod linux_landlock {
             let writable: Vec<&PathBuf> = policy
                 .writable_roots
                 .iter()
+                .chain(&policy.metadata_writable_roots)
                 .filter(|r| r.exists())
                 .collect();
             if !writable.is_empty() {
@@ -488,6 +499,8 @@ mod tests {
                 readable_roots: Vec::new(),
                 allowed_unix_socket_roots: Vec::new(),
                 writable_roots: Vec::new(),
+                metadata_protection_roots: Vec::new(),
+                metadata_writable_roots: Vec::new(),
                 read_only_roots: Vec::new(),
                 denied_roots: Vec::new(),
                 network_access: false,
@@ -544,6 +557,8 @@ mod tests {
                 readable_roots: Vec::new(),
                 allowed_unix_socket_roots: Vec::new(),
                 writable_roots: vec![workspace.path().to_path_buf()],
+                metadata_protection_roots: vec![workspace.path().to_path_buf()],
+                metadata_writable_roots: Vec::new(),
                 read_only_roots: vec![workspace.path().join(".git")],
                 denied_roots: Vec::new(),
                 network_access: false,
@@ -559,6 +574,38 @@ mod tests {
     }
 
     #[test]
+    fn nested_read_only_policy_without_backend_fails_closed_when_non_strict() {
+        if bwrap_path(Path::new(".")).is_some() {
+            return;
+        }
+        let workspace = tempfile::tempdir().unwrap();
+        let metadata = workspace.path().join(".git");
+        let marker = workspace.path().join("must-not-run");
+        std::fs::create_dir(&metadata).unwrap();
+        let request = LinuxSandboxRequest {
+            command: format!("touch {}", marker.display()),
+            policy: LinuxSandboxPolicy {
+                cwd: workspace.path().to_path_buf(),
+                read_scope: LinuxReadScope::Global,
+                readable_roots: Vec::new(),
+                allowed_unix_socket_roots: Vec::new(),
+                writable_roots: vec![workspace.path().to_path_buf()],
+                metadata_protection_roots: vec![workspace.path().to_path_buf()],
+                metadata_writable_roots: Vec::new(),
+                read_only_roots: vec![metadata],
+                denied_roots: Vec::new(),
+                network_access: true,
+            },
+            strict: false,
+        };
+
+        let output = sandbox_command(request).output().unwrap();
+
+        assert_eq!(output.status.code(), Some(126));
+        assert!(!marker.exists());
+    }
+
+    #[test]
     fn unix_socket_exceptions_require_bwrap_when_network_is_disabled() {
         let workspace = tempfile::tempdir().unwrap();
         let socket_root = tempfile::tempdir().unwrap();
@@ -570,6 +617,8 @@ mod tests {
                 readable_roots: Vec::new(),
                 allowed_unix_socket_roots: vec![socket_root.path().to_path_buf()],
                 writable_roots: Vec::new(),
+                metadata_protection_roots: Vec::new(),
+                metadata_writable_roots: Vec::new(),
                 read_only_roots: Vec::new(),
                 denied_roots: Vec::new(),
                 network_access: false,

--- a/crates/orca-tools/src/sandbox/mod.rs
+++ b/crates/orca-tools/src/sandbox/mod.rs
@@ -20,6 +20,43 @@ pub fn is_protected_metadata_root(path: &Path) -> bool {
         .is_some_and(|name| PROTECTED_METADATA_DIRS.contains(&name))
 }
 
+pub fn is_safe_metadata_writable_root(path: &Path) -> bool {
+    if !is_protected_metadata_root(path) {
+        return false;
+    }
+    match std::fs::symlink_metadata(path) {
+        // A path that does not exist yet cannot be a symlink escape; the
+        // sandbox platform layers re-check and canonicalize at launch time.
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => true,
+        Ok(metadata) => !metadata.file_type().is_symlink(),
+        Err(_) => false,
+    }
+}
+
+#[cfg(all(test, unix))]
+mod metadata_root_tests {
+    use super::*;
+
+    #[test]
+    fn metadata_grant_rejects_symlinked_metadata_directory() {
+        let parent = tempfile::tempdir().unwrap();
+        let workspace = parent.path().join("workspace");
+        let metadata = workspace.join(".git");
+        std::fs::create_dir_all(&metadata).unwrap();
+        let outside = parent.path().join("outside");
+        std::fs::create_dir(&outside).unwrap();
+        let agents_link = workspace.join(".agents");
+        std::os::unix::fs::symlink(&outside, &agents_link).unwrap();
+
+        assert!(is_safe_metadata_writable_root(
+            &metadata.canonicalize().unwrap()
+        ));
+        assert!(is_safe_metadata_writable_root(&workspace.join(".codex")));
+        // A symlink with a protected name must never become a writable grant.
+        assert!(!is_safe_metadata_writable_root(&agents_link));
+    }
+}
+
 /// Platform read roots a Linux shell runtime needs when the sandbox root is a
 /// fresh tmpfs. Exposed here so the pure `bwrap` argv builder (compiled on all
 /// platforms) can consult the same list the Linux backend uses.
@@ -263,7 +300,7 @@ mod platform {
             &context
                 .metadata_writable_roots
                 .iter()
-                .filter(|root| is_protected_metadata_root(root))
+                .filter(|root| is_safe_metadata_writable_root(root))
                 .cloned()
                 .collect::<Vec<_>>(),
         );
@@ -273,11 +310,7 @@ mod platform {
                 writable_roots.push(root.clone());
             }
         }
-        for root in &metadata_writable_roots {
-            if !writable_roots.contains(root) {
-                writable_roots.push(root.clone());
-            }
-        }
+        let metadata_protection_roots = writable_roots.clone();
         if !context.exclude_slash_tmp {
             writable_roots.push(PathBuf::from("/tmp"));
         }
@@ -318,6 +351,8 @@ mod platform {
                 readable_roots: canonicalize_all(context.readable_roots),
                 allowed_unix_socket_roots: canonicalize_all(context.allowed_unix_socket_roots),
                 writable_roots,
+                metadata_protection_roots,
+                metadata_writable_roots,
                 read_only_roots,
                 denied_roots,
                 network_access: context.network_access,
@@ -414,19 +449,15 @@ mod platform {
         // Additional roots are writable even in read-only mode (e.g. an
         // explicitly granted output directory), matching the Seatbelt profile.
         let mut writable_roots = canonicalize_all(context.additional_roots);
+        let metadata_protection_roots = writable_roots.clone();
         let metadata_writable_roots = canonicalize_all(
             &context
                 .metadata_writable_roots
                 .iter()
-                .filter(|root| is_protected_metadata_root(root))
+                .filter(|root| is_safe_metadata_writable_root(root))
                 .cloned()
                 .collect::<Vec<_>>(),
         );
-        for root in &metadata_writable_roots {
-            if !writable_roots.contains(root) {
-                writable_roots.push(root.clone());
-            }
-        }
 
         let mut read_only_roots = Vec::new();
         for name in PROTECTED_METADATA_DIRS {
@@ -460,6 +491,8 @@ mod platform {
                 readable_roots: canonicalize_all(context.readable_roots),
                 allowed_unix_socket_roots: canonicalize_all(context.allowed_unix_socket_roots),
                 writable_roots,
+                metadata_protection_roots,
+                metadata_writable_roots,
                 read_only_roots,
                 denied_roots,
                 network_access: context.network_access,

--- a/crates/orca-tools/src/sandbox/seatbelt.rs
+++ b/crates/orca-tools/src/sandbox/seatbelt.rs
@@ -129,7 +129,7 @@ pub fn workspace_write_bash_command(context: WorkspaceWriteSandboxCommandContext
     let canonical_metadata_writable_roots = context
         .metadata_writable_roots
         .iter()
-        .filter(|root| crate::sandbox::is_protected_metadata_root(root))
+        .filter(|root| crate::sandbox::is_safe_metadata_writable_root(root))
         .map(|root| normalize_path_for_seatbelt(root))
         .collect::<Vec<_>>();
     let canonical_denied_roots = context
@@ -176,7 +176,7 @@ pub fn read_only_bash_command(context: ReadOnlySandboxCommandContext<'_>) -> Com
     let canonical_metadata_writable_roots = context
         .metadata_writable_roots
         .iter()
-        .filter(|root| crate::sandbox::is_protected_metadata_root(root))
+        .filter(|root| crate::sandbox::is_safe_metadata_writable_root(root))
         .map(|root| normalize_path_for_seatbelt(root))
         .collect::<Vec<_>>();
     let canonical_additional_roots = context
@@ -1132,6 +1132,39 @@ mod tests {
             &workspace,
             &[parent.path().to_path_buf()],
         )
+        .output()
+        .unwrap();
+
+        assert!(!output.status.success());
+        assert!(!target.exists());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn workspace_write_sandbox_rejects_explicit_symlinked_metadata_root() {
+        assert_seatbelt_available();
+
+        let parent = TempDir::new_in(std::env::current_dir().unwrap()).unwrap();
+        let workspace = parent.path().join("workspace");
+        let metadata_target = parent.path().join("external-target");
+        let metadata_link = workspace.join(".agents");
+        std::fs::create_dir(&workspace).unwrap();
+        std::fs::create_dir(&metadata_target).unwrap();
+        std::os::unix::fs::symlink(&metadata_target, &metadata_link).unwrap();
+        let target = metadata_target.join("blocked.txt");
+
+        let output = workspace_write_bash_command(WorkspaceWriteSandboxCommandContext {
+            command: &format!("printf blocked > {}", target.display()),
+            cwd: &workspace,
+            readable_roots: &[],
+            additional_roots: &[],
+            metadata_writable_roots: std::slice::from_ref(&metadata_link),
+            denied_roots: &[],
+            network_access: true,
+            exclude_tmpdir_env_var: true,
+            exclude_slash_tmp: true,
+            allowed_unix_socket_roots: &[],
+        })
         .output()
         .unwrap();
 

--- a/docs/superpowers/specs/2026-07-28-native-windows-platform-foundation.manifest.json
+++ b/docs/superpowers/specs/2026-07-28-native-windows-platform-foundation.manifest.json
@@ -334,7 +334,7 @@
       "seatbelt-unix-api",
       "crates/orca-tools/src/sandbox/seatbelt.rs",
       "unix_std_api",
-      5,
+      6,
       "windows-sandbox-plan"
     ],
     [
@@ -399,6 +399,27 @@
       "unix_libc_process",
       2,
       "windows-test-portability"
+    ],
+    [
+      "runtime-permission-test-symlink",
+      "crates/orca-runtime/src/runtime_permission.rs",
+      "unix_std_api",
+      1,
+      "windows-test-portability"
+    ],
+    [
+      "bwrap-sandbox-test-symlink",
+      "crates/orca-tools/src/sandbox/bwrap.rs",
+      "unix_std_api",
+      1,
+      "windows-sandbox-plan"
+    ],
+    [
+      "sandbox-metadata-test-symlink",
+      "crates/orca-tools/src/sandbox/mod.rs",
+      "unix_std_api",
+      1,
+      "windows-sandbox-plan"
     ]
   ]
 }

--- a/tests/server_runtime_contract.rs
+++ b/tests/server_runtime_contract.rs
@@ -1207,17 +1207,47 @@ fn server_thread_directory_update_cannot_forge_metadata_escalation() {
             .load_session(&thread_id)
             .expect("load session");
         assert!(
-            persisted
+            !persisted
                 .meta
                 .additional_working_directories
                 .iter()
                 .any(|directory| {
                     directory.path == git_dir && directory.source == "session-metadata"
-                })
+                }),
+            "reserved metadata sources must be ignored by ordinary directory updates"
         );
         assert!(
             persisted.meta.metadata_writable_directories.is_empty(),
             "ordinary permission updates must not mint metadata escalation authority"
+        );
+    });
+}
+
+#[test]
+fn server_thread_start_cannot_forge_metadata_escalation() {
+    with_orca_home(|home| {
+        let mut runtime = start_server_runtime();
+        let mut config = test_run_config(home);
+        config.history_mode = HistoryMode::Record;
+        let git_dir = home.join(".git");
+        std::fs::create_dir_all(&git_dir).expect("git dir");
+        config.additional_working_directories = vec![AdditionalWorkingDirectory::new(
+            git_dir.clone(),
+            "session-metadata",
+        )];
+
+        let thread_id = runtime.start_thread(&config).expect("start thread");
+        let persisted = SessionStore::new()
+            .load_session(&thread_id)
+            .expect("load session");
+
+        assert!(
+            persisted.meta.additional_working_directories.is_empty(),
+            "reserved metadata sources must be ignored at the runtime boundary"
+        );
+        assert!(
+            persisted.meta.metadata_writable_directories.is_empty(),
+            "runtime configuration must not mint metadata escalation authority"
         );
     });
 }

--- a/tests/session_server_contract.rs
+++ b/tests/session_server_contract.rs
@@ -2015,9 +2015,10 @@ fn server_mode_interrupt_cancels_active_pre_model_hook_wait() {
     let interrupt = child.expect_event("interrupt-hook", "turn_controlled");
     assert_eq!(interrupt["status"], "interrupted");
     let completed = child.expect_event("turn-hook", "turn_completed");
+    let interrupt_elapsed = interrupt_sent_at.elapsed();
     assert!(
-        interrupt_sent_at.elapsed() < Duration::from_millis(1200),
-        "turn completion waited for the full pre_model hook sleep"
+        interrupt_elapsed < Duration::from_secs(3),
+        "turn completion waited too long for pre_model hook cancellation: {interrupt_elapsed:?}"
     );
     assert_eq!(completed["status"], "cancelled");
 

--- a/tests/subagent_contract.rs
+++ b/tests/subagent_contract.rs
@@ -190,7 +190,7 @@ fn subagent_status_can_read_persisted_async_handle() {
         ])
         .output()
         .expect("run orca");
-    assert_eq!(launched.status.code(), Some(0));
+    assert_launched_ok(&launched);
     let launch_events = parse_jsonl(&launched.stdout);
     let launch_completed = find_event(&launch_events, "tool.call.completed");
     let launch_payload: Value =
@@ -246,7 +246,7 @@ fn async_subagent_completes_after_launching_exec_process_exits() {
         ])
         .output()
         .expect("run orca");
-    assert_eq!(launched.status.code(), Some(0));
+    assert_launched_ok(&launched);
     let launch_events = parse_jsonl(&launched.stdout);
     let launch_completed = find_event(&launch_events, "tool.call.completed");
     let launch_payload: Value =
@@ -397,7 +397,7 @@ fn async_subagent_schema_failure_persists_failed_task() {
         ])
         .output()
         .expect("run orca");
-    assert_eq!(launched.status.code(), Some(0));
+    assert_launched_ok(&launched);
     let launch_events = parse_jsonl(&launched.stdout);
     let launch_completed = find_event(&launch_events, "tool.call.completed");
     let launch_payload: Value =
@@ -572,6 +572,18 @@ fn subagent_cli_test_guard() -> MutexGuard<'static, ()> {
     SUBAGENT_CLI_TEST_LOCK
         .lock()
         .unwrap_or_else(std::sync::PoisonError::into_inner)
+}
+
+fn assert_launched_ok(output: &std::process::Output) {
+    // Surface the child's captured streams so a Windows-only async launch
+    // failure is diagnosable from CI instead of collapsing to `Some(1)`.
+    assert_eq!(
+        output.status.code(),
+        Some(0),
+        "orca exec exited non-zero\n--- stdout ---\n{}\n--- stderr ---\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
 }
 
 fn run_git(cwd: &std::path::Path, args: &[&str]) {

--- a/tests/tui_pty_contract.rs
+++ b/tests/tui_pty_contract.rs
@@ -101,6 +101,13 @@ fn tui_permission_round_trips_through_the_runtime_surface() {
             "TUI did not resume after the typed permission response",
         );
     }
+    receive_until(
+        &process,
+        &mut output,
+        "Mock completed after tool execution.",
+        Duration::from_secs(10),
+        "TUI did not complete after the approved tool execution",
+    );
 
     arm_idle_exit(&mut process, &mut output);
     let status = process.wait_for_exit(Duration::from_secs(5));


### PR DESCRIPTION
## Summary

Rebased and reconciled against current `main` (v0.4.0 + runtime/provider optimization commit + CI baseline refresh). The original July branch no longer applied cleanly after the v0.3.25/v0.3.26/v0.4.0 refactors, so the fix was re-implemented surgically:

**Sandbox hardening (the security core):**
- Linux/bubblewrap discovers existing nested protected metadata (`.git`/`.agents`/`.codex`) under writable roots before launch and re-binds it read-only; symlinked metadata roots cannot widen an explicit grant; metadata write authority stays provenance-separate from ordinary writable roots.
- macOS/Seatbelt filters granted metadata roots through `is_safe_metadata_writable_root` (rejects symlinked metadata dirs; not-yet-created protected paths remain admissible because the sandbox re-checks at launch).
- The runtime permission overlay, `command_exec` sandbox resolution, and session-grant materialization record protected metadata roots only when they pass the safety guard.
- Reserved `session-metadata` directory sources are ignored at the runtime thread boundary and by ordinary permission updates (no forged-config escalation).
- Bash and the tool router keep protected metadata paths out of ordinary additional working directories.

**Also in this PR:**
- Mock provider reuses fresh tool ids across turns and stops after a result (enables multi-turn denial-retry tests).
- Windows platform boundary manifest registers the new unix-only symlink fixtures.
- Test stabilization: TUI permission round-trip awaits turn completion, subagent launches surface stdout/stderr on Windows failure, hook-cancellation timing bound relaxed, background-handoff ordering superseded by the release-marker test on main.

**Explicitly dropped from the original branch** (superseded by v0.3.26 session-grant machinery and the v0.4.0 controller split): the surface-settings provenance plumbing and the atomic-commit refactor in `runtime_host.rs`/`surface_adapter.rs`, plus test extensions that depended on them. `surface_session_permission_settings_delta_authorized` already gates settings deltas against live permission requests on main.

## Verification

- `cargo check --workspace --all-targets --locked` clean
- `cargo nextest`: orca-tools 232/232, orca-runtime lib 1238/1238, orca-tui lib 1210/1210, session_server_contract + server_runtime_contract 163/163, subagent_contract + tui_pty_contract 13/13
- Runtime Surface Contract validator + self-test, Windows platform boundary validator + self-test — all pass
- Repository hygiene, terminal_bench — pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Security**
  - Improved sandbox protection for sensitive metadata directories.
  - Unsafe or symlinked metadata paths are no longer granted writable access.
  - Restricted sandbox policies now fail safely instead of falling back to unsandboxed execution.

- **Bug Fixes**
  - Prevented permission updates and session startup settings from bypassing metadata protections.
  - Improved multi-turn tool execution so consecutive tool calls receive unique identifiers and stop correctly after completion.
  - Improved reliability of timeout and interrupt handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->