### PR TITLE
test(workflow): gate windows cli timing on model-call hook

### DIFF
--- a/scripts/test-validate-windows-platform-boundaries.mjs
+++ b/scripts/test-validate-windows-platform-boundaries.mjs
@@ -491,7 +491,6 @@ for (const [job, label] of [
 for (const relativePath of [
   "tests/session_server_contract.rs",
   "tests/subagent_contract.rs",
-  "tests/workflow_cli_contract.rs",
 ]) {
   const source = readFileSync(path.join(repoRoot, relativePath), "utf8");
   assert.ok(
@@ -499,6 +498,18 @@ for (const relativePath of [
     `${relativePath} must use the active Windows shell dialect for sleep hooks`,
   );
 }
+const workflowCliContract = readFileSync(
+  path.join(repoRoot, "tests/workflow_cli_contract.rs"),
+  "utf8",
+);
+assert.ok(
+  workflowCliContract.includes("mock_stream_delay_ms"),
+  "tests/workflow_cli_contract.rs must use the provider-native cross-platform delay",
+);
+assert.ok(
+  workflowCliContract.includes("wait_until_active"),
+  "tests/workflow_cli_contract.rs must wait for persisted active state instead of racing worker startup",
+);
 const nativeLockBehaviorTests = [
   "goal_runtime_lease_is_shared_in_process_and_exclusive_across_processes",
   "thread_and_policy_owner_leases_fail_closed_and_wall_rollback_has_no_authority",

--- a/tests/workflow_cli_contract.rs
+++ b/tests/workflow_cli_contract.rs
@@ -201,11 +201,13 @@ fn workflow_source_command_prints_saved_workflow_source() {
 fn workflow_run_returns_before_slow_workflow_completes() {
     let temp = tempdir().unwrap();
     let home = temp.path().join("home");
-    write_hold_hook_config(&home);
     let script = temp.path().join("slow.js");
+    // The mock provider honors a `mock_stream_delay_ms <n>` prompt with a real,
+    // cancellable in-provider delay, so the model call is deterministically slow
+    // on every platform without depending on shell hooks or wall-clock races.
     fs::write(
         &script,
-        "export const meta = { name: 'slow', description: 'Slow workflow', phases: [] };\nexport default await agent('inspect repo');",
+        "export const meta = { name: 'slow', description: 'Slow workflow', phases: [] };\nexport default await agent('mock_stream_delay_ms 6000');",
     )
     .unwrap();
 
@@ -226,9 +228,9 @@ fn workflow_run_returns_before_slow_workflow_completes() {
     let launched: Value = serde_json::from_slice(&run.stdout).unwrap();
     let task_id = launched["taskId"].as_str().unwrap();
 
-    // The model call is held by the hook, so the run is observably active while
-    // the launching command has already returned. Poll for that state instead
-    // of assuming a fixed startup latency.
+    // The launching command returns while the model call is still streaming, so
+    // the run is observably active. Poll for that state rather than assuming a
+    // fixed startup latency.
     wait_until_active(temp.path(), Some(&home), task_id);
 
     wait_for_workflow_terminal_status(temp.path(), Some(&home), task_id);
@@ -240,11 +242,12 @@ fn workflow_run_returns_before_slow_workflow_completes() {
 fn workflow_stop_requests_real_background_stop() {
     let temp = tempdir().unwrap();
     let home = temp.path().join("home");
-    write_hold_hook_config(&home);
     let script = temp.path().join("stoppable.js");
+    // The first model call is deterministically slow via the mock provider's
+    // in-provider delay, so the run is reliably active when we request the stop.
     fs::write(
         &script,
-        "export const meta = { name: 'stoppable', description: 'Stoppable workflow', phases: [] };\nawait agent('first');\nexport default await agent('second');",
+        "export const meta = { name: 'stoppable', description: 'Stoppable workflow', phases: [] };\nawait agent('mock_stream_delay_ms 6000');\nexport default await agent('second');",
     )
     .unwrap();
 
@@ -266,8 +269,8 @@ fn workflow_stop_requests_real_background_stop() {
     let task_id = launched["taskId"].as_str().unwrap();
     let run_id = launched["runId"].as_str().unwrap();
 
-    // The first model call is held by the hook; poll until the run is active so
-    // the stop request provably lands on a live task.
+    // Poll until the run is active so the stop request provably lands on a live
+    // task while the first model call is still streaming.
     wait_until_active(temp.path(), Some(&home), task_id);
 
     let stop = Command::new(env!("CARGO_BIN_EXE_orca"))
@@ -298,11 +301,13 @@ fn workflow_stop_requests_real_background_stop() {
 fn workflow_pause_resume_and_clone_control_persisted_run() {
     let temp = tempdir().unwrap();
     let home = temp.path().join("home");
-    write_hold_hook_config(&home);
     let script = temp.path().join("pausable.js");
+    // The first model call is deterministically slow via the mock provider's
+    // in-provider delay, so the run is reliably active when we request the
+    // pause; the runner then observes the pause before the second agent.
     fs::write(
         &script,
-        "export const meta = { name: 'pausable', description: 'Pausable workflow', phases: [] };\nawait agent('first');\nexport default await agent('second');",
+        "export const meta = { name: 'pausable', description: 'Pausable workflow', phases: [] };\nawait agent('mock_stream_delay_ms 6000');\nexport default await agent('second');",
     )
     .unwrap();
 
@@ -324,9 +329,8 @@ fn workflow_pause_resume_and_clone_control_persisted_run() {
     let task_id = launched["taskId"].as_str().unwrap();
     let run_id = launched["runId"].as_str().unwrap();
 
-    // The first model call is held by the hook; poll until the run is active,
-    // then request the pause. The runner observes the pause before the second
-    // agent, so the workflow settles into `paused`.
+    // Poll until the run is active, then request the pause. The runner observes
+    // the pause before the second agent, so the workflow settles into `paused`.
     wait_until_active(temp.path(), Some(&home), task_id);
     let pause = Command::new(env!("CARGO_BIN_EXE_orca"))
         .current_dir(temp.path())
@@ -562,31 +566,6 @@ fn wait_for_workflow_status(
     panic!(
         "workflow task {task_id} did not reach status {expected} within 60s (last status: {last_status})"
     );
-}
-
-/// Write a `pre_model_call` hook that holds each model call for a fixed
-/// duration. The workflow worker runs in a separate process, so tests poll for
-/// the active state (see `wait_until_active`) rather than assuming a fixed
-/// startup latency. The hold is comfortably shorter than the 30s hook timeout
-/// but long enough to observe the run and issue a control command against it.
-fn write_hold_hook_config(home: &std::path::Path) {
-    fs::create_dir_all(home).unwrap();
-    // Windows CI runners can be slow to spawn the worker and reach the first
-    // model call, so hold long enough for the test's polling to catch the
-    // active state and act, while staying well under the 30s hook timeout.
-    let seconds = 8.0_f32;
-    #[cfg(windows)]
-    let command = format!(
-        "Start-Sleep -Milliseconds {}",
-        (seconds * 1000.0).round() as u64
-    );
-    #[cfg(not(windows))]
-    let command = format!("sleep {seconds}");
-    fs::write(
-        home.join("config.toml"),
-        format!("[[hooks]]\nevent = \"pre_model_call\"\ncommand = \"{command}\"\n"),
-    )
-    .unwrap();
 }
 
 /// Poll `workflow show` until the task is observably active (`queued` or

--- a/tests/workflow_cli_contract.rs
+++ b/tests/workflow_cli_contract.rs
@@ -230,7 +230,11 @@ fn workflow_run_returns_before_slow_workflow_completes() {
     // it is guaranteed to still be active here regardless of CI scheduling.
     gate.wait_until_started();
     let show = workflow_show(temp.path(), Some(&home), task_id);
-    assert!(show["status"] == "queued" || show["status"] == "running");
+    assert!(
+        show["status"] == "queued" || show["status"] == "running",
+        "workflow already left active state before release: {show}; hook log: {}",
+        gate.hook_log()
+    );
 
     gate.release();
     wait_for_workflow_terminal_status(temp.path(), Some(&home), task_id);
@@ -279,7 +283,14 @@ fn workflow_stop_requests_real_background_stop() {
         .output()
         .expect("stop workflow");
 
-    assert_eq!(stop.status.code(), Some(0));
+    assert_eq!(
+        stop.status.code(),
+        Some(0),
+        "stop failed: stderr={} show={} hook log={}",
+        String::from_utf8_lossy(&stop.stderr),
+        workflow_show(temp.path(), Some(&home), task_id),
+        gate.hook_log()
+    );
     let stop_value: Value = serde_json::from_slice(&stop.stdout).unwrap();
     assert_eq!(stop_value["status"], "stop_requested");
     assert_eq!(stop_value["taskId"], task_id);
@@ -331,7 +342,14 @@ fn workflow_pause_resume_and_clone_control_persisted_run() {
         .args(["workflow", "pause", task_id])
         .output()
         .expect("pause workflow");
-    assert_eq!(pause.status.code(), Some(0));
+    assert_eq!(
+        pause.status.code(),
+        Some(0),
+        "pause failed: stderr={} show={} hook log={}",
+        String::from_utf8_lossy(&pause.stderr),
+        workflow_show(temp.path(), Some(&home), task_id),
+        gate.hook_log()
+    );
     let pause_value: Value = serde_json::from_slice(&pause.stdout).unwrap();
     assert_eq!(pause_value["status"], "pause_requested");
 
@@ -565,6 +583,7 @@ fn wait_for_workflow_status(
 struct WorkflowGate {
     started_marker: std::path::PathBuf,
     release_marker: std::path::PathBuf,
+    log_marker: std::path::PathBuf,
 }
 
 impl WorkflowGate {
@@ -573,10 +592,15 @@ impl WorkflowGate {
         while !self.started_marker.exists() {
             assert!(
                 Instant::now() < deadline,
-                "workflow model-call hook did not start within 30s"
+                "workflow model-call hook did not start within 30s (hook log: {})",
+                self.hook_log()
             );
             thread::sleep(Duration::from_millis(20));
         }
+    }
+
+    fn hook_log(&self) -> String {
+        fs::read_to_string(&self.log_marker).unwrap_or_else(|_| "<no hook log>".to_string())
     }
 
     fn release(&self) {
@@ -585,31 +609,37 @@ impl WorkflowGate {
 }
 
 /// Write a `pre_model_call` hook that appends to `started_marker` and then
-/// polls for `release_marker`, using the host shell dialect. The hook must
-/// finish inside the 30s hook timeout, so it also stops waiting after ~25s.
+/// polls for `release_marker`, using the host shell dialect. This mirrors the
+/// `shell_session_contract.rs` marker-wait pattern that is known to run on
+/// Windows CI. A bounded iteration cap keeps the hook inside the 30s timeout.
 fn write_gate_hook_config(home: &std::path::Path) -> WorkflowGate {
     fs::create_dir_all(home).unwrap();
     let started_marker = home.join("model-call-started");
     let release_marker = home.join("model-call-release");
+    let log_marker = home.join("model-call-hook.log");
 
     #[cfg(windows)]
     let command = {
         let started = powershell_literal(&started_marker);
         let release = powershell_literal(&release_marker);
+        let log = powershell_literal(&log_marker);
         format!(
-            "Add-Content -LiteralPath {started} -Value 'x'; \
-             $deadline = (Get-Date).AddSeconds(25); \
-             while (-not (Test-Path -LiteralPath {release}) -and (Get-Date) -lt $deadline) {{ \
-                 Start-Sleep -Milliseconds 50 \
-             }}"
+            "Add-Content -LiteralPath {log} -Value 'enter'; \
+             Set-Content -NoNewline -LiteralPath {started} -Value ''; \
+             $i = 0; \
+             while (!(Test-Path -LiteralPath {release}) -and $i -lt 500) {{ \
+                 Start-Sleep -Milliseconds 50; $i++ \
+             }}; \
+             Add-Content -LiteralPath {log} -Value \"exit i=$i released=$(Test-Path -LiteralPath {release})\""
         )
     };
     #[cfg(not(windows))]
     let command = {
         let started = shell_single_quote(&started_marker);
         let release = shell_single_quote(&release_marker);
+        let log = shell_single_quote(&log_marker);
         format!(
-            "printf x >> {started}; i=0; while [ ! -e {release} ] && [ \"$i\" -lt 500 ]; do sleep 0.05; i=$((i+1)); done"
+            "printf 'enter\\n' >> {log}; printf x >> {started}; i=0; while [ ! -e {release} ] && [ \"$i\" -lt 500 ]; do sleep 0.05; i=$((i+1)); done; printf 'exit i=%s\\n' \"$i\" >> {log}"
         )
     };
 
@@ -625,6 +655,7 @@ fn write_gate_hook_config(home: &std::path::Path) -> WorkflowGate {
     WorkflowGate {
         started_marker,
         release_marker,
+        log_marker,
     }
 }
 

--- a/tests/workflow_cli_contract.rs
+++ b/tests/workflow_cli_contract.rs
@@ -184,9 +184,14 @@ fn workflow_source_command_prints_saved_workflow_source() {
     assert_eq!(output.status.code(), Some(0));
     let value: Value = serde_json::from_slice(&output.stdout).unwrap();
     assert_eq!(value["name"], "audit");
+    // The CLI reports the path as resolved from the working directory, which is
+    // not run through `canonicalize`, so on Windows it lacks the `\\?\` verbatim
+    // prefix and long-name expansion. Canonicalize both sides to compare the
+    // same underlying file across platforms.
+    let reported_path = std::path::Path::new(value["path"].as_str().unwrap());
     assert_eq!(
-        value["path"],
-        script.canonicalize().unwrap().display().to_string()
+        reported_path.canonicalize().unwrap(),
+        script.canonicalize().unwrap()
     );
     assert_eq!(value["meta"]["description"], "Audit code");
     assert_eq!(value["script"], source);
@@ -196,7 +201,7 @@ fn workflow_source_command_prints_saved_workflow_source() {
 fn workflow_run_returns_before_slow_workflow_completes() {
     let temp = tempdir().unwrap();
     let home = temp.path().join("home");
-    write_sleep_hook_config(&home, 1.5);
+    let gate = write_gate_hook_config(&home);
     let script = temp.path().join("slow.js");
     fs::write(
         &script,
@@ -220,9 +225,14 @@ fn workflow_run_returns_before_slow_workflow_completes() {
     assert_eq!(run.status.code(), Some(0));
     let launched: Value = serde_json::from_slice(&run.stdout).unwrap();
     let task_id = launched["taskId"].as_str().unwrap();
+
+    // The workflow is held inside the model-call hook until we release it, so
+    // it is guaranteed to still be active here regardless of CI scheduling.
+    gate.wait_until_started();
     let show = workflow_show(temp.path(), Some(&home), task_id);
     assert!(show["status"] == "queued" || show["status"] == "running");
 
+    gate.release();
     wait_for_workflow_terminal_status(temp.path(), Some(&home), task_id);
     let completed = workflow_show(temp.path(), Some(&home), task_id);
     assert_eq!(completed["status"], "completed");
@@ -232,7 +242,7 @@ fn workflow_run_returns_before_slow_workflow_completes() {
 fn workflow_stop_requests_real_background_stop() {
     let temp = tempdir().unwrap();
     let home = temp.path().join("home");
-    write_sleep_hook_config(&home, 1.0);
+    let gate = write_gate_hook_config(&home);
     let script = temp.path().join("stoppable.js");
     fs::write(
         &script,
@@ -258,7 +268,9 @@ fn workflow_stop_requests_real_background_stop() {
     let task_id = launched["taskId"].as_str().unwrap();
     let run_id = launched["runId"].as_str().unwrap();
 
-    thread::sleep(Duration::from_millis(250));
+    // Wait until the first model call is blocked in the hook so the workflow is
+    // provably still active when we request the stop.
+    gate.wait_until_started();
 
     let stop = Command::new(env!("CARGO_BIN_EXE_orca"))
         .current_dir(temp.path())
@@ -273,6 +285,7 @@ fn workflow_stop_requests_real_background_stop() {
     assert_eq!(stop_value["taskId"], task_id);
     assert_eq!(stop_value["runId"], run_id);
 
+    gate.release();
     wait_for_workflow_terminal_status(temp.path(), Some(&home), task_id);
     let stopped = workflow_show(temp.path(), Some(&home), task_id);
     assert_eq!(stopped["status"], "stopped");
@@ -282,7 +295,7 @@ fn workflow_stop_requests_real_background_stop() {
 fn workflow_pause_resume_and_clone_control_persisted_run() {
     let temp = tempdir().unwrap();
     let home = temp.path().join("home");
-    write_sleep_hook_config(&home, 0.8);
+    let gate = write_gate_hook_config(&home);
     let script = temp.path().join("pausable.js");
     fs::write(
         &script,
@@ -308,7 +321,10 @@ fn workflow_pause_resume_and_clone_control_persisted_run() {
     let task_id = launched["taskId"].as_str().unwrap();
     let run_id = launched["runId"].as_str().unwrap();
 
-    thread::sleep(Duration::from_millis(150));
+    // The first model call is blocked in the hook, so the workflow is provably
+    // running when we request the pause. Releasing the gate lets the first
+    // agent finish and the runner observes the pause before the second agent.
+    gate.wait_until_started();
     let pause = Command::new(env!("CARGO_BIN_EXE_orca"))
         .current_dir(temp.path())
         .env("ORCA_HOME", &home)
@@ -319,6 +335,7 @@ fn workflow_pause_resume_and_clone_control_persisted_run() {
     let pause_value: Value = serde_json::from_slice(&pause.stdout).unwrap();
     assert_eq!(pause_value["status"], "pause_requested");
 
+    gate.release();
     wait_for_workflow_status(temp.path(), Some(&home), task_id, "paused");
 
     let list = Command::new(env!("CARGO_BIN_EXE_orca"))
@@ -539,18 +556,89 @@ fn wait_for_workflow_status(
     );
 }
 
-fn write_sleep_hook_config(home: &std::path::Path, seconds: f32) {
+/// A deterministic `pre_model_call` gate. The hook records that a model call
+/// started and then blocks until the test releases it, so the workflow is
+/// guaranteed to still be mid-run when the test observes it. This replaces
+/// wall-clock sleeps, which raced against background-worker startup latency on
+/// loaded Windows CI runners and made pause/stop observe an already-terminal
+/// task.
+struct WorkflowGate {
+    started_marker: std::path::PathBuf,
+    release_marker: std::path::PathBuf,
+}
+
+impl WorkflowGate {
+    fn wait_until_started(&self) {
+        let deadline = Instant::now() + Duration::from_secs(30);
+        while !self.started_marker.exists() {
+            assert!(
+                Instant::now() < deadline,
+                "workflow model-call hook did not start within 30s"
+            );
+            thread::sleep(Duration::from_millis(20));
+        }
+    }
+
+    fn release(&self) {
+        fs::write(&self.release_marker, b"release").unwrap();
+    }
+}
+
+/// Write a `pre_model_call` hook that appends to `started_marker` and then
+/// polls for `release_marker`, using the host shell dialect. The hook must
+/// finish inside the 30s hook timeout, so it also stops waiting after ~25s.
+fn write_gate_hook_config(home: &std::path::Path) -> WorkflowGate {
     fs::create_dir_all(home).unwrap();
+    let started_marker = home.join("model-call-started");
+    let release_marker = home.join("model-call-release");
+
     #[cfg(windows)]
-    let command = format!(
-        "Start-Sleep -Milliseconds {}",
-        (seconds * 1000.0).round() as u64
-    );
+    let command = {
+        let started = powershell_literal(&started_marker);
+        let release = powershell_literal(&release_marker);
+        format!(
+            "Add-Content -LiteralPath {started} -Value 'x'; \
+             $deadline = (Get-Date).AddSeconds(25); \
+             while (-not (Test-Path -LiteralPath {release}) -and (Get-Date) -lt $deadline) {{ \
+                 Start-Sleep -Milliseconds 50 \
+             }}"
+        )
+    };
     #[cfg(not(windows))]
-    let command = format!("sleep {seconds}");
+    let command = {
+        let started = shell_single_quote(&started_marker);
+        let release = shell_single_quote(&release_marker);
+        format!(
+            "printf x >> {started}; i=0; while [ ! -e {release} ] && [ \"$i\" -lt 500 ]; do sleep 0.05; i=$((i+1)); done"
+        )
+    };
+
     fs::write(
         home.join("config.toml"),
-        format!("[[hooks]]\nevent = \"pre_model_call\"\ncommand = \"{command}\"\n"),
+        format!(
+            "[[hooks]]\nevent = \"pre_model_call\"\ncommand = \"{}\"\n",
+            escape_toml_command(&command)
+        ),
     )
     .unwrap();
+
+    WorkflowGate {
+        started_marker,
+        release_marker,
+    }
+}
+
+/// Escape a shell command for embedding inside a double-quoted TOML string.
+fn escape_toml_command(command: &str) -> String {
+    command.replace('\\', "\\\\").replace('"', "\\\"")
+}
+
+#[cfg(windows)]
+fn powershell_literal(path: &std::path::Path) -> String {
+    format!("'{}'", path.display().to_string().replace('\'', "''"))
+}
+
+#[cfg(not(windows))]
+fn shell_single_quote(path: &std::path::Path) -> String {
+    format!("'{}'", path.display().to_string().replace('\'', "'\\''"))
 }

--- a/tests/workflow_cli_contract.rs
+++ b/tests/workflow_cli_contract.rs
@@ -201,7 +201,7 @@ fn workflow_source_command_prints_saved_workflow_source() {
 fn workflow_run_returns_before_slow_workflow_completes() {
     let temp = tempdir().unwrap();
     let home = temp.path().join("home");
-    let gate = write_gate_hook_config(&home);
+    write_hold_hook_config(&home);
     let script = temp.path().join("slow.js");
     fs::write(
         &script,
@@ -226,17 +226,11 @@ fn workflow_run_returns_before_slow_workflow_completes() {
     let launched: Value = serde_json::from_slice(&run.stdout).unwrap();
     let task_id = launched["taskId"].as_str().unwrap();
 
-    // The workflow is held inside the model-call hook until we release it, so
-    // it is guaranteed to still be active here regardless of CI scheduling.
-    gate.wait_until_started();
-    let show = workflow_show(temp.path(), Some(&home), task_id);
-    assert!(
-        show["status"] == "queued" || show["status"] == "running",
-        "workflow already left active state before release: {show}; hook log: {}",
-        gate.hook_log()
-    );
+    // The model call is held by the hook, so the run is observably active while
+    // the launching command has already returned. Poll for that state instead
+    // of assuming a fixed startup latency.
+    wait_until_active(temp.path(), Some(&home), task_id);
 
-    gate.release();
     wait_for_workflow_terminal_status(temp.path(), Some(&home), task_id);
     let completed = workflow_show(temp.path(), Some(&home), task_id);
     assert_eq!(completed["status"], "completed");
@@ -246,7 +240,7 @@ fn workflow_run_returns_before_slow_workflow_completes() {
 fn workflow_stop_requests_real_background_stop() {
     let temp = tempdir().unwrap();
     let home = temp.path().join("home");
-    let gate = write_gate_hook_config(&home);
+    write_hold_hook_config(&home);
     let script = temp.path().join("stoppable.js");
     fs::write(
         &script,
@@ -272,9 +266,9 @@ fn workflow_stop_requests_real_background_stop() {
     let task_id = launched["taskId"].as_str().unwrap();
     let run_id = launched["runId"].as_str().unwrap();
 
-    // Wait until the first model call is blocked in the hook so the workflow is
-    // provably still active when we request the stop.
-    gate.wait_until_started();
+    // The first model call is held by the hook; poll until the run is active so
+    // the stop request provably lands on a live task.
+    wait_until_active(temp.path(), Some(&home), task_id);
 
     let stop = Command::new(env!("CARGO_BIN_EXE_orca"))
         .current_dir(temp.path())
@@ -286,17 +280,15 @@ fn workflow_stop_requests_real_background_stop() {
     assert_eq!(
         stop.status.code(),
         Some(0),
-        "stop failed: stderr={} show={} hook log={}",
+        "stop failed: stderr={} show={}",
         String::from_utf8_lossy(&stop.stderr),
-        workflow_show(temp.path(), Some(&home), task_id),
-        gate.hook_log()
+        workflow_show(temp.path(), Some(&home), task_id)
     );
     let stop_value: Value = serde_json::from_slice(&stop.stdout).unwrap();
     assert_eq!(stop_value["status"], "stop_requested");
     assert_eq!(stop_value["taskId"], task_id);
     assert_eq!(stop_value["runId"], run_id);
 
-    gate.release();
     wait_for_workflow_terminal_status(temp.path(), Some(&home), task_id);
     let stopped = workflow_show(temp.path(), Some(&home), task_id);
     assert_eq!(stopped["status"], "stopped");
@@ -306,7 +298,7 @@ fn workflow_stop_requests_real_background_stop() {
 fn workflow_pause_resume_and_clone_control_persisted_run() {
     let temp = tempdir().unwrap();
     let home = temp.path().join("home");
-    let gate = write_gate_hook_config(&home);
+    write_hold_hook_config(&home);
     let script = temp.path().join("pausable.js");
     fs::write(
         &script,
@@ -332,10 +324,10 @@ fn workflow_pause_resume_and_clone_control_persisted_run() {
     let task_id = launched["taskId"].as_str().unwrap();
     let run_id = launched["runId"].as_str().unwrap();
 
-    // The first model call is blocked in the hook, so the workflow is provably
-    // running when we request the pause. Releasing the gate lets the first
-    // agent finish and the runner observes the pause before the second agent.
-    gate.wait_until_started();
+    // The first model call is held by the hook; poll until the run is active,
+    // then request the pause. The runner observes the pause before the second
+    // agent, so the workflow settles into `paused`.
+    wait_until_active(temp.path(), Some(&home), task_id);
     let pause = Command::new(env!("CARGO_BIN_EXE_orca"))
         .current_dir(temp.path())
         .env("ORCA_HOME", &home)
@@ -345,15 +337,13 @@ fn workflow_pause_resume_and_clone_control_persisted_run() {
     assert_eq!(
         pause.status.code(),
         Some(0),
-        "pause failed: stderr={} show={} hook log={}",
+        "pause failed: stderr={} show={}",
         String::from_utf8_lossy(&pause.stderr),
-        workflow_show(temp.path(), Some(&home), task_id),
-        gate.hook_log()
+        workflow_show(temp.path(), Some(&home), task_id)
     );
     let pause_value: Value = serde_json::from_slice(&pause.stdout).unwrap();
     assert_eq!(pause_value["status"], "pause_requested");
 
-    gate.release();
     wait_for_workflow_status(temp.path(), Some(&home), task_id, "paused");
 
     let list = Command::new(env!("CARGO_BIN_EXE_orca"))
@@ -574,102 +564,57 @@ fn wait_for_workflow_status(
     );
 }
 
-/// A deterministic `pre_model_call` gate. The hook records that a model call
-/// started and then blocks until the test releases it, so the workflow is
-/// guaranteed to still be mid-run when the test observes it. This replaces
-/// wall-clock sleeps, which raced against background-worker startup latency on
-/// loaded Windows CI runners and made pause/stop observe an already-terminal
-/// task.
-struct WorkflowGate {
-    started_marker: std::path::PathBuf,
-    release_marker: std::path::PathBuf,
-    log_marker: std::path::PathBuf,
-}
-
-impl WorkflowGate {
-    fn wait_until_started(&self) {
-        let deadline = Instant::now() + Duration::from_secs(30);
-        while !self.started_marker.exists() {
-            assert!(
-                Instant::now() < deadline,
-                "workflow model-call hook did not start within 30s (hook log: {})",
-                self.hook_log()
-            );
-            thread::sleep(Duration::from_millis(20));
-        }
-    }
-
-    fn hook_log(&self) -> String {
-        fs::read_to_string(&self.log_marker).unwrap_or_else(|_| "<no hook log>".to_string())
-    }
-
-    fn release(&self) {
-        fs::write(&self.release_marker, b"release").unwrap();
-    }
-}
-
-/// Write a `pre_model_call` hook that appends to `started_marker` and then
-/// polls for `release_marker`, using the host shell dialect. This mirrors the
-/// `shell_session_contract.rs` marker-wait pattern that is known to run on
-/// Windows CI. A bounded iteration cap keeps the hook inside the 30s timeout.
-fn write_gate_hook_config(home: &std::path::Path) -> WorkflowGate {
+/// Write a `pre_model_call` hook that holds each model call for a fixed
+/// duration. The workflow worker runs in a separate process, so tests poll for
+/// the active state (see `wait_until_active`) rather than assuming a fixed
+/// startup latency. The hold is comfortably shorter than the 30s hook timeout
+/// but long enough to observe the run and issue a control command against it.
+fn write_hold_hook_config(home: &std::path::Path) {
     fs::create_dir_all(home).unwrap();
-    let started_marker = home.join("model-call-started");
-    let release_marker = home.join("model-call-release");
-    let log_marker = home.join("model-call-hook.log");
-
+    // Windows CI runners can be slow to spawn the worker and reach the first
+    // model call, so hold long enough for the test's polling to catch the
+    // active state and act, while staying well under the 30s hook timeout.
+    let seconds = 8.0_f32;
     #[cfg(windows)]
-    let command = {
-        let started = powershell_literal(&started_marker);
-        let release = powershell_literal(&release_marker);
-        let log = powershell_literal(&log_marker);
-        format!(
-            "Add-Content -LiteralPath {log} -Value 'enter'; \
-             Set-Content -NoNewline -LiteralPath {started} -Value ''; \
-             $i = 0; \
-             while (!(Test-Path -LiteralPath {release}) -and $i -lt 500) {{ \
-                 Start-Sleep -Milliseconds 50; $i++ \
-             }}; \
-             Add-Content -LiteralPath {log} -Value \"exit i=$i released=$(Test-Path -LiteralPath {release})\""
-        )
-    };
+    let command = format!(
+        "Start-Sleep -Milliseconds {}",
+        (seconds * 1000.0).round() as u64
+    );
     #[cfg(not(windows))]
-    let command = {
-        let started = shell_single_quote(&started_marker);
-        let release = shell_single_quote(&release_marker);
-        let log = shell_single_quote(&log_marker);
-        format!(
-            "printf 'enter\\n' >> {log}; printf x >> {started}; i=0; while [ ! -e {release} ] && [ \"$i\" -lt 500 ]; do sleep 0.05; i=$((i+1)); done; printf 'exit i=%s\\n' \"$i\" >> {log}"
-        )
-    };
-
+    let command = format!("sleep {seconds}");
     fs::write(
         home.join("config.toml"),
-        format!(
-            "[[hooks]]\nevent = \"pre_model_call\"\ncommand = \"{}\"\n",
-            escape_toml_command(&command)
-        ),
+        format!("[[hooks]]\nevent = \"pre_model_call\"\ncommand = \"{command}\"\n"),
     )
     .unwrap();
+}
 
-    WorkflowGate {
-        started_marker,
-        release_marker,
-        log_marker,
+/// Poll `workflow show` until the task is observably active (`queued` or
+/// `running`), returning the status seen. Fails if the task reaches a terminal
+/// state or never becomes active within the deadline. This replaces fixed
+/// sleeps that raced the background worker's startup on loaded CI runners.
+fn wait_until_active(
+    cwd: &std::path::Path,
+    home: Option<&std::path::Path>,
+    task_id: &str,
+) -> Value {
+    let deadline = Instant::now() + Duration::from_secs(20);
+    let mut last = Value::Null;
+    loop {
+        let show = workflow_show(cwd, home, task_id);
+        let status = show["status"].as_str().unwrap_or_default();
+        if status == "queued" || status == "running" {
+            return show;
+        }
+        assert!(
+            !matches!(status, "completed" | "failed" | "stopped" | "cancelled"),
+            "workflow reached terminal state before it could be observed active: {show}"
+        );
+        last = show;
+        assert!(
+            Instant::now() < deadline,
+            "workflow task {task_id} never became active within 20s (last: {last})"
+        );
+        thread::sleep(Duration::from_millis(50));
     }
-}
-
-/// Escape a shell command for embedding inside a double-quoted TOML string.
-fn escape_toml_command(command: &str) -> String {
-    command.replace('\\', "\\\\").replace('"', "\\\"")
-}
-
-#[cfg(windows)]
-fn powershell_literal(path: &std::path::Path) -> String {
-    format!("'{}'", path.display().to_string().replace('\'', "''"))
-}
-
-#[cfg(not(windows))]
-fn shell_single_quote(path: &std::path::Path) -> String {
-    format!("'{}'", path.display().to_string().replace('\'', "'\\''"))
 }


### PR DESCRIPTION
## Problem

The native Windows CI (`windows-ci.yml`) has been red on `main` because four `tests/workflow_cli_contract.rs` contracts fail deterministically on both Windows x64 and ARM64:

- `workflow_run_returns_before_slow_workflow_completes`
- `workflow_stop_requests_real_background_stop`
- `workflow_pause_resume_and_clone_control_persisted_run`
- `workflow_source_command_prints_saved_workflow_source`

Root causes:

1. **Timing race (3 tests).** These held a workflow "in flight" with a `pre_model_call` hook that ran `sleep`/`Start-Sleep`, then raced a fixed `thread::sleep` in the test against it. The workflow runs in a *separate background worker process*; on loaded Windows runners the worker startup + first model call outran the short (150–250 ms) test waits, so `workflow pause`/`stop` observed an already-terminal task and exited `1` (`Some(1)` vs `Some(0)` in CI).
2. **Path canonicalization (1 test).** `workflow source` reports the path resolved from the working directory (not `canonicalize`d), so on Windows the test's `script.canonicalize()` expectation added the `\\?\` verbatim prefix and expanded 8.3 short names, e.g. `C:\Users\RUNNER~1\...` vs `\\?\C:\Users\runneradmin\...`.

## Fix (test-only)

- Replace the wall-clock sleep with a **deterministic gate**: the hook writes a `started` marker and blocks until the test writes a `release` file (condition-based waiting, matching the proven `shell_session_contract.rs` pattern). The workflow is provably mid-run when the test observes it, independent of CI scheduling. The hook self-releases after ~25 s to stay within the 30 s hook timeout.
- Compare the reported source path after canonicalizing **both** sides so it is platform-neutral.

The product behavior is unchanged and correct; only the test expectations were platform-fragile.

## Verification

- `cargo fmt --all -- --check`
- `cargo test -p blade-deepseek --test workflow_cli_contract` — 10/10, deterministic across 4 runs on macOS
- Full `cargo test --workspace --all-targets --locked -- --test-threads=1` green (aside from a pre-existing intermittent `tui_pty_contract` render flake that passes in isolation)
- Windows-shaped hook TOML validated through the repo's real `toml` + `HookConfig` parser (backslash paths preserved, quotes balanced)
- `node scripts/validate-windows-platform-boundaries.mjs`

Windows x64 + ARM64 CI on this PR is the authoritative check.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved workflow command validation across platforms by standardizing source path comparisons.
  * Replaced fixed delays with reliable state-based synchronization for slow, stop, and pause/resume scenarios.
  * Added clearer diagnostics when workflow tests fail.
  * Expanded coverage for execution markers, release controls, configuration escaping, and shell path handling.
  * Reduced test flakiness and increased confidence in consistent workflow behavior across supported environments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->