### PR TITLE
test(workflow): classify active state by exclusion, not allowlist

### DIFF
--- a/tests/workflow_cli_contract.rs
+++ b/tests/workflow_cli_contract.rs
@@ -603,9 +603,9 @@ fn wait_for_workflow_status(
     );
 }
 
-/// Poll `workflow show` until the task is observably active (`queued` or
-/// `running`), returning the status seen. Fails if the task reaches a terminal
-/// state or never becomes active within the deadline. This replaces fixed
+/// Poll `workflow show` until the task is observably active (any non-terminal
+/// status), returning the status seen. Fails if the task reaches a terminal
+/// state or never reports a status within the deadline. This replaces fixed
 /// sleeps that raced the background worker's startup on loaded CI runners.
 fn wait_until_active(
     cwd: &std::path::Path,
@@ -613,19 +613,31 @@ fn wait_until_active(
     task_id: &str,
 ) -> Value {
     let deadline = Instant::now() + Duration::from_secs(20);
+    let mut seen: Vec<String> = Vec::new();
     loop {
         let show = workflow_show(cwd, home, task_id);
         let status = show["status"].as_str().unwrap_or_default();
-        if status == "queued" || status == "running" {
-            return show;
+        if seen.last().map(String::as_str) != Some(status) {
+            seen.push(status.to_string());
         }
         assert!(
             !matches!(status, "completed" | "failed" | "stopped" | "cancelled"),
-            "workflow reached terminal state before it could be observed active: {show}"
+            "workflow reached terminal state before it could be observed active \
+             (status sequence: {seen:?}): {show}"
         );
+        // Classify by exclusion, not by allowlist. `WorkflowRunStatus` has nine
+        // variants; an allowlist of `queued`/`running` left the rest in a gap
+        // where the loop neither returned nor failed, so it spun for the whole
+        // run and only tripped once the run went terminal. Any non-terminal
+        // status means the run is live, which is all these tests need before
+        // issuing pause/stop. The status sequence is reported on failure so a
+        // future gap names itself instead of looking like a timing flake.
+        if !status.is_empty() {
+            return show;
+        }
         assert!(
             Instant::now() < deadline,
-            "workflow task {task_id} never became active within 20s (last: {show})"
+            "workflow task {task_id} never reported a status within 20s (last: {show})"
         );
         thread::sleep(Duration::from_millis(50));
     }


### PR DESCRIPTION
## 为什么之前一直修不好

失败长得像 timing flake，于是过去几个 commit 全在调时序、调 gate、调等待方式。但真正的问题在判定逻辑，调时间碰不到它。

三个失败的测试恰好是**唯一调用 `wait_until_active()` 的三个**，x64 / arm64 稳定 7 passed / 3 failed，两个架构一致。稳定复现 + 精确对应一个 helper —— 不是竞态。

`wait_until_active` 用白名单判定活跃：只认 `queued`/`running`（2 个），只防 4 个 terminal 态。但 `WorkflowRunStatus` 有 **9 个**变体，剩下的掉进缝里：不返回、不报错、继续空转，直到 run 结束变 terminal 才失败 —— 失败现场因此永远显示 `completed`，看着就像"跑太快了"，于是下一轮又去加延迟。

## 改了什么

`tests/workflow_cli_contract.rs`：

- **判定反过来**：先排除 terminal，其余非空状态都算已观测到活跃。9 个变体里任何一个都不会再让循环静默空转。
- **失败信息带上状态序列**：下次万一还挂，日志直接点名是哪个状态，而不是又一个"看起来像 flake"。
- **补上 `workflow_run_returns_before_slow_workflow_completes` 名字承诺、却从没断言过的契约**：`workflow run` 必须在 6s 模型调用结束**之前**返回。

## 待验证

本地 macOS 10/10 通过，但**旧代码在 macOS 上本来也过** —— 这证明不了 Windows 修好了。这次改动的定性是：消除一整类静默空转 + 装上能点名的诊断。Windows 跑出来的**状态序列**才会确认或推翻判断。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Expanded validation of workflow status transitions, including distinct state changes and clearer diagnostics when workflows finish unexpectedly.
  * Improved timeout reporting to show the workflow’s most recently displayed state.
  * Verified that non-terminal workflow statuses are handled as active while operations remain in progress.
  * No end-user functionality changes are included in this update.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->