### PR TITLE
release: v0.3.7 session context convergence

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -204,7 +204,7 @@ checksum = "84d7ced0ae9557296835c32bf1b1e02b44c746701f898460fb000d7eaa84f00a"
 
 [[package]]
 name = "blade-deepseek"
-version = "0.3.6"
+version = "0.3.7"
 dependencies = [
  "base64",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,7 +48,7 @@ windows-sys = "0.61"
 
 [package]
 name = "blade-deepseek"
-version = "0.3.6"
+version = "0.3.7"
 edition = "2024"
 description = "Orca: a DeepSeek-native coding agent"
 license = "MIT"

--- a/crates/orca-core/src/config/mod.rs
+++ b/crates/orca-core/src/config/mod.rs
@@ -952,10 +952,7 @@ mod tests {
             show_session_picker: false,
             active_permission_profile: Some(ActivePermissionProfile::new("strict", Some("base"))),
             permission_profiles: HashMap::new(),
-            runtime_workspace_roots: Some(vec![
-                PathBuf::from("/workspace"),
-                PathBuf::from("job"),
-            ]),
+            runtime_workspace_roots: Some(vec![PathBuf::from("/workspace"), PathBuf::from("job")]),
             permission_rules: PermissionRules {
                 rules: vec![PermissionRule::new("bash", "cargo *", Decision::Allow)],
             },

--- a/crates/orca-runtime/src/runtime_host.rs
+++ b/crates/orca-runtime/src/runtime_host.rs
@@ -7575,6 +7575,12 @@ fn bootstrap_recorded_surface(
     incarnation_bytes[8] = 0x80 | (incarnation_bytes[8] & 0x3f);
     let incarnation = surface::SurfaceIncarnation::try_from_bytes(incarnation_bytes)
         .expect("normalized thread UUID is v7");
+    let restored_context_tokens =
+        crate::thread_store::read_latest_context_tokens(&path).map_err(|error| {
+            RuntimeHostError::ThreadStartFailed {
+                message: format!("failed to restore latest provider context: {error}"),
+            }
+        })?;
 
     let owner_lease = surface_owner.owner_lease;
     let current_owner_epoch = surface::ThreadOwnerEpoch::new(owner_lease.owner_epoch());
@@ -7586,6 +7592,7 @@ fn bootstrap_recorded_surface(
         surface::ThreadPersistence::RecordedCatalogued,
         config,
         title,
+        restored_context_tokens,
     )?;
     let ledger = surface::JsonlSurfaceCommitLedger::new(path, snapshot.cursor.clone());
     let mut coordinator = surface::RuntimeCommitCoordinator::recover_with_owned_lease(
@@ -7755,6 +7762,7 @@ fn bootstrap_ephemeral_surface(
         surface::ThreadPersistence::EphemeralNonCataloguedOneShot { close_after },
         config,
         title,
+        None,
     )?;
     let ledger = surface::RuntimeSurfaceCommitLedger::Ephemeral(
         surface::InMemorySurfaceCommitLedger::new(snapshot.cursor.clone()),
@@ -7888,6 +7896,7 @@ fn initial_surface_snapshot(
     persistence: surface::ThreadPersistence,
     config: &RunConfig,
     title: &str,
+    restored_context_tokens: Option<u64>,
 ) -> Result<surface::SurfaceSnapshot, RuntimeHostError> {
     let cwd = config.cwd.clone().unwrap_or_else(|| {
         std::env::current_dir().unwrap_or_else(|_| std::path::PathBuf::from("/"))
@@ -7999,6 +8008,11 @@ fn initial_surface_snapshot(
     let permission_rules_digest = surface_sha256(
         &serde_json::to_vec(&permission_rules).expect("surface permission rules are serializable"),
     );
+    let context_limit_tokens = config
+        .model_runtime
+        .context_window
+        .unwrap_or_else(|| orca_core::model::max_context_tokens(config.model.as_deref()))
+        .max(1) as u64;
     let settings = surface::SurfaceRuntimeSettings {
         model: surface::NonEmptyText::try_new(
             config
@@ -8083,8 +8097,8 @@ fn initial_surface_snapshot(
         },
         context: surface::SurfaceContextSnapshot {
             revision: surface::ContextRevision::try_new(1).expect("one is a valid revision"),
-            used_tokens: 0,
-            limit_tokens: 128_000,
+            used_tokens: restored_context_tokens.unwrap_or(0),
+            limit_tokens: context_limit_tokens,
             compaction: surface::CompactionState::Idle,
             fragments: Vec::new(),
             provider_replay: surface::ProviderReplayHealth::None,
@@ -50279,6 +50293,75 @@ mod tests {
             Some(previous) => unsafe { std::env::set_var("ORCA_HOME", previous) },
             None => unsafe { std::env::remove_var("ORCA_HOME") },
         }
+    }
+
+    #[test]
+    fn resumed_legacy_usage_restores_latest_provider_context() {
+        let _env = crate::history::lock_test_env();
+        let home = tempfile::tempdir().unwrap();
+        let _home = OrcaHomeRestore::set(home.path());
+        let cwd = tempfile::tempdir().unwrap();
+
+        let host = RuntimeHost::start_with_executor(Arc::new(PanicExecutor))
+            .expect("start legacy context fixture host");
+        let thread = host
+            .start_thread(
+                surface_test_config(cwd.path().to_path_buf(), HistoryMode::Record),
+                "legacy context fixture",
+            )
+            .expect("start legacy context fixture thread");
+        let thread_id = thread.thread_id().to_string();
+        let transcript_path = SessionStore::new()
+            .load_session(&thread_id)
+            .expect("load legacy context fixture")
+            .path;
+        thread
+            .shutdown()
+            .expect("shutdown legacy context fixture thread");
+        host.shutdown()
+            .expect("shutdown legacy context fixture host");
+
+        let mut writer = crate::thread_store::SessionWriter::append_to_existing(transcript_path)
+            .expect("open legacy context fixture transcript");
+        writer
+            .append_usage(UsageTotals {
+                input_tokens: 929_128,
+                output_tokens: 10_260,
+                cache_tokens: 893_696,
+                estimated_cost_usd: 0.063661744,
+            })
+            .expect("append penultimate usage snapshot");
+        writer
+            .append_usage(UsageTotals {
+                input_tokens: 970_611,
+                output_tokens: 10_627,
+                cache_tokens: 935_040,
+                estimated_cost_usd: 0.065860634,
+            })
+            .expect("append latest usage snapshot");
+        drop(writer);
+
+        let resumed_host = RuntimeHost::start_with_executor(Arc::new(PanicExecutor))
+            .expect("start resumed legacy context host");
+        let resumed = resumed_host
+            .start_thread(
+                surface_test_config(cwd.path().to_path_buf(), HistoryMode::Resume(thread_id)),
+                "resume legacy context fixture",
+            )
+            .expect("resume legacy context fixture");
+        let snapshot = fresh_surface_attachment(&resumed.surface())
+            .baseline
+            .snapshot;
+
+        assert_eq!(snapshot.context.used_tokens, 41_483);
+        assert_eq!(snapshot.context.limit_tokens, 1_000_000);
+
+        resumed
+            .shutdown()
+            .expect("shutdown resumed legacy context thread");
+        resumed_host
+            .shutdown()
+            .expect("shutdown resumed legacy context host");
     }
 
     #[test]

--- a/crates/orca-runtime/src/thread_store.rs
+++ b/crates/orca-runtime/src/thread_store.rs
@@ -31,7 +31,9 @@ pub use types::{
     TurnItemsView,
 };
 pub use writer::SessionWriter;
-pub(crate) use writer::{read_manual_compaction_snapshot, redact_sensitive_text};
+pub(crate) use writer::{
+    read_latest_context_tokens, read_manual_compaction_snapshot, redact_sensitive_text,
+};
 
 pub(crate) fn resume_conversation(
     transcript: &SessionTranscript,

--- a/crates/orca-runtime/src/thread_store/writer.rs
+++ b/crates/orca-runtime/src/thread_store/writer.rs
@@ -431,6 +431,27 @@ pub(crate) fn read_transcript(path: &Path) -> io::Result<SessionTranscript> {
     })
 }
 
+pub(crate) fn read_latest_context_tokens(path: &Path) -> io::Result<Option<u64>> {
+    let mut previous_input_tokens = 0;
+    let mut latest_context_tokens = None;
+    for record in read_records(path)? {
+        match record {
+            SessionRecord::Usage(usage) => {
+                latest_context_tokens = Some(
+                    usage
+                        .input_tokens
+                        .checked_sub(previous_input_tokens)
+                        .unwrap_or(usage.input_tokens),
+                );
+                previous_input_tokens = usage.input_tokens;
+            }
+            SessionRecord::UsageBaseline(_) => previous_input_tokens = 0,
+            _ => {}
+        }
+    }
+    Ok(latest_context_tokens)
+}
+
 fn redact_session_record(record: &SessionRecord) -> SessionRecord {
     let mut redacted = record.clone();
     match &mut redacted {
@@ -1302,6 +1323,19 @@ mod tests {
             })
             .collect::<Vec<_>>();
         assert_eq!(values, vec![8_000]);
+    }
+
+    #[test]
+    fn latest_context_tokens_are_the_delta_between_usage_snapshots() {
+        let (_directory, path, mut writer) = new_transcript();
+        writer
+            .append_usage(usage(929_128, 10_260, 893_696, 0.06))
+            .expect("write penultimate usage snapshot");
+        writer
+            .append_usage(usage(970_611, 10_627, 935_040, 0.06))
+            .expect("write latest usage snapshot");
+
+        assert_eq!(read_latest_context_tokens(&path).unwrap(), Some(41_483));
     }
 
     #[test]

--- a/crates/orca-tui/src/app.rs
+++ b/crates/orca-tui/src/app.rs
@@ -58,7 +58,8 @@ use crate::surface_actions::{TuiHostActions, TuiSurfaceActions};
 use crate::terminal_presentation::{TerminalPresentation, TerminalPresentationProfile};
 use crate::theme::Theme;
 use crate::types::{
-    AppState, AppStatus, AttachedTuiEvent, ChatMessage, SessionAttachmentId, TuiEvent, UserAction,
+    AppState, AppStatus, AttachedTuiEvent, ChatMessage, SessionAttachmentId,
+    SurfaceProjectionState, TuiEvent, UserAction,
 };
 use crate::ui;
 use crate::vim::{PendingInsertEscapeFlow, VimState};
@@ -5244,6 +5245,48 @@ done
     }
 
     #[test]
+    fn resumed_legacy_usage_projects_context_before_next_turn() {
+        with_orca_home(|home| {
+            let mut writer =
+                history::SessionWriter::start(home, "mock", Some("auto".to_string()), "context")
+                    .expect("create legacy context transcript");
+            writer
+                .append_usage(orca_core::cost_types::UsageTotals {
+                    input_tokens: 929_128,
+                    output_tokens: 10_260,
+                    cache_tokens: 893_696,
+                    estimated_cost_usd: 0.063661744,
+                })
+                .expect("append penultimate usage snapshot");
+            writer
+                .append_usage(orca_core::cost_types::UsageTotals {
+                    input_tokens: 970_611,
+                    output_tokens: 10_627,
+                    cache_tokens: 935_040,
+                    estimated_cost_usd: 0.065860634,
+                })
+                .expect("append latest usage snapshot");
+            drop(writer);
+            let session_id = history::load_session("latest")
+                .expect("load legacy context transcript")
+                .meta
+                .session_id;
+
+            let mut harness =
+                HostedTuiHarness::start(test_config(HistoryMode::Resume(session_id)), None);
+            let event =
+                harness.recv_until(|event| matches!(event, TuiEvent::SurfaceProjectionSynced(_)));
+            let TuiEvent::SurfaceProjectionSynced(projection) = event else {
+                unreachable!("predicate accepted only a surface projection")
+            };
+            assert_eq!(projection.context_used_tokens, 41_483);
+            assert_eq!(projection.context_limit_tokens, 1_000_000);
+
+            harness.shutdown();
+        });
+    }
+
+    #[test]
     fn empty_recorded_hosted_tui_goal_resume_restores_latest_active_goal() {
         with_orca_home(|home| {
             let mut writer =
@@ -9169,6 +9212,11 @@ fn emit_typed_history_snapshot(
             plan,
             label: label.to_string(),
         })
+        .map_err(|error| error.to_string())?;
+    event_tx
+        .send(TuiEvent::SurfaceProjectionSynced(Box::new(
+            SurfaceProjectionState::from_surface_snapshot(&snapshot),
+        )))
         .map_err(|error| error.to_string())?;
     let tasks = crate::surface_projection::workflow_task_summaries(&snapshot);
     if !tasks.is_empty() {

--- a/crates/orca-tui/src/surface_projection.rs
+++ b/crates/orca-tui/src/surface_projection.rs
@@ -165,12 +165,13 @@ pub(crate) enum SurfaceProjectionError {
 pub(crate) type TuiStreamDeliveryWatermark = BTreeMap<SurfaceStreamId, ByteOffset>;
 
 impl SurfaceProjectionState {
-    fn from_surface_snapshot(snapshot: &orca_runtime::surface::SurfaceSnapshot) -> Self {
+    pub(crate) fn from_surface_snapshot(snapshot: &orca_runtime::surface::SurfaceSnapshot) -> Self {
         Self {
             session_id: surface_thread_id_text(&snapshot.thread.thread_id),
             title: snapshot.thread.title.as_str().to_string(),
             usage_revision: snapshot.usage.revision.get(),
             usage: core_usage_totals(&snapshot.usage.thread_total),
+            context_revision: snapshot.context.revision.get(),
             context_used_tokens: usize::try_from(snapshot.context.used_tokens)
                 .unwrap_or(usize::MAX),
             context_limit_tokens: usize::try_from(snapshot.context.limit_tokens)
@@ -194,6 +195,7 @@ impl SurfaceProjectionState {
 pub(crate) struct TuiSurfaceProjection {
     cursor: SurfaceCursor,
     assistant_streams: BTreeMap<SurfaceStreamId, SurfaceAssistantStream>,
+    assistant_stream_order: Vec<SurfaceStreamId>,
     completed_items: Vec<SurfaceItem>,
     operation_turn_ids: BTreeMap<SurfaceOperationId, Vec<orca_runtime::surface::SurfaceTurnId>>,
     focused_operation: Option<SurfaceOperationId>,
@@ -208,6 +210,10 @@ impl TuiSurfaceProjection {
     pub(crate) fn from_snapshot(cursor: SurfaceCursor, streams: &[SurfaceAssistantStream]) -> Self {
         Self {
             cursor,
+            assistant_stream_order: streams
+                .iter()
+                .map(|stream| stream.stream_id.clone())
+                .collect(),
             assistant_streams: streams
                 .iter()
                 .map(|stream| (stream.stream_id.clone(), stream.clone()))
@@ -286,8 +292,9 @@ impl TuiSurfaceProjection {
             })
             .unwrap_or_default();
         projected.extend(
-            self.assistant_streams
-                .values()
+            self.assistant_stream_order
+                .iter()
+                .filter_map(|stream_id| self.assistant_streams.get(stream_id))
                 .filter(|stream| {
                     stream.state == SurfaceAssistantStreamState::Open
                         && !stream.text.as_str().is_empty()
@@ -326,8 +333,9 @@ impl TuiSurfaceProjection {
         watermark: &TuiStreamDeliveryWatermark,
     ) -> Result<Vec<TuiEvent>, SurfaceProjectionError> {
         let mut projected = self
-            .assistant_streams
-            .values()
+            .assistant_stream_order
+            .iter()
+            .filter_map(|stream_id| self.assistant_streams.get(stream_id))
             .filter(|stream| {
                 &stream.fence.operation_id == operation_id
                     && stream.state != SurfaceAssistantStreamState::Discarded
@@ -492,12 +500,16 @@ impl TuiSurfaceProjection {
         };
 
         let mut assistant_streams = self.assistant_streams.clone();
+        let mut assistant_stream_order = self.assistant_stream_order.clone();
         let mut focused_operation = self.focused_operation.clone();
         let mut goal = self.goal.clone();
         let mut projected = Vec::new();
         for envelope in batch.events.as_slice() {
             match &envelope.event {
                 SurfaceEvent::Assistant(AssistantPatch::StreamOpened { stream }) => {
+                    if !assistant_streams.contains_key(&stream.stream_id) {
+                        assistant_stream_order.push(stream.stream_id.clone());
+                    }
                     assistant_streams
                         .entry(stream.stream_id.clone())
                         .and_modify(|current| *current = stream.clone())
@@ -544,13 +556,17 @@ impl TuiSurfaceProjection {
                     }
                 }
                 SurfaceEvent::Assistant(AssistantPatch::ResponseCompleted { response }) => {
+                    let response_matches_streams =
+                        response_matches_streamed_items(response, assistant_streams.values());
                     for stream in assistant_streams.values_mut().filter(|stream| {
                         stream.turn_id == response.turn_id
                             && stream.state == SurfaceAssistantStreamState::Open
                     }) {
                         stream.state = SurfaceAssistantStreamState::Completed;
                     }
-                    projected.push(response_completed_event(response));
+                    if !response_matches_streams {
+                        projected.push(response_completed_event(response));
+                    }
                 }
                 SurfaceEvent::Tool(ToolPatch::Requested { request }) => {
                     projected.push(TuiEvent::ToolRequested {
@@ -792,6 +808,7 @@ impl TuiSurfaceProjection {
             }
         }
         self.assistant_streams = assistant_streams;
+        self.assistant_stream_order = assistant_stream_order;
         self.focused_operation = focused_operation;
         self.goal = goal;
         self.reducer_state = next_reducer_state;
@@ -1356,14 +1373,53 @@ fn response_completed_event(response: &SurfaceCompletedModelResponse) -> TuiEven
     )
 }
 
+fn response_matches_streamed_items<'a>(
+    response: &SurfaceCompletedModelResponse,
+    streams: impl Iterator<Item = &'a SurfaceAssistantStream>,
+) -> bool {
+    let streams = streams
+        .filter(|stream| {
+            stream.turn_id == response.turn_id
+                && stream.state != SurfaceAssistantStreamState::Discarded
+        })
+        .collect::<Vec<_>>();
+    let expected = [
+        response
+            .message_item
+            .as_ref()
+            .map(|item| (&item.id, AssistantChannel::Message, item.text.as_str())),
+        response
+            .reasoning_item
+            .as_ref()
+            .map(|item| (&item.id, AssistantChannel::Reasoning, item.content.as_str())),
+        response
+            .plan_item
+            .as_ref()
+            .map(|item| (&item.id, AssistantChannel::Plan, item.text.as_str())),
+    ]
+    .into_iter()
+    .flatten()
+    .collect::<Vec<_>>();
+
+    streams.len() == expected.len()
+        && expected.iter().all(|(item_id, channel, text)| {
+            streams.iter().any(|stream| {
+                &stream.item_id == *item_id
+                    && stream.channel == *channel
+                    && stream.text.as_str() == *text
+            })
+        })
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
     use orca_runtime::surface::{
         ByteOffset, CommitClass, CursorSourceRevision, DisplayText, DurableRevision, NonEmptyVec,
-        SequenceNumber, Sha256Digest, SurfaceCommitId, SurfaceEventEnvelope, SurfaceEventId,
-        SurfaceIncarnation, SurfaceInputCorrelationId, SurfaceItemId, SurfaceScope,
-        SurfaceThreadId, SurfaceTurnId, ThreadOwnerEpoch,
+        SequenceNumber, Sha256Digest, SurfaceAssistantMessageItem, SurfaceAssistantReasoningItem,
+        SurfaceCommitId, SurfaceEventEnvelope, SurfaceEventId, SurfaceIncarnation,
+        SurfaceInputCorrelationId, SurfaceItemId, SurfaceScope, SurfaceThreadId, SurfaceTurnId,
+        ThreadOwnerEpoch, UuidV7,
     };
     use orca_runtime::surface::{SurfaceGenerationId, SurfaceUsageSnapshot, UsageRevision};
 
@@ -1508,6 +1564,93 @@ mod tests {
             Err(SurfaceProjectionError::UnknownAssistantStream { stream_id: observed })
                 if observed == stream_id
         ));
+    }
+
+    #[test]
+    fn completed_response_does_not_reproject_identical_streamed_content() {
+        let before = cursor(0, 1);
+        let fence = operation_fence(12);
+        let turn_id = SurfaceTurnId::new();
+        let reasoning_item_id = SurfaceItemId::new();
+        let message_item_id = SurfaceItemId::new();
+        let reasoning_stream = SurfaceAssistantStream {
+            stream_id: SurfaceStreamId::try_from_bytes(uuid_v7_bytes(13))
+                .expect("reasoning stream id"),
+            fence: fence.clone(),
+            turn_id: turn_id.clone(),
+            item_id: reasoning_item_id.clone(),
+            channel: AssistantChannel::Reasoning,
+            next_offset: ByteOffset::new(6),
+            text: DisplayText::new("reason"),
+            state: SurfaceAssistantStreamState::Open,
+        };
+        let message_stream = SurfaceAssistantStream {
+            stream_id: SurfaceStreamId::try_from_bytes(uuid_v7_bytes(14))
+                .expect("message stream id"),
+            fence: fence.clone(),
+            turn_id: turn_id.clone(),
+            item_id: message_item_id.clone(),
+            channel: AssistantChannel::Message,
+            next_offset: ByteOffset::new(6),
+            text: DisplayText::new("answer"),
+            state: SurfaceAssistantStreamState::Open,
+        };
+        let commit_class = CommitClass::Recorded {
+            thread_owner_epoch: ThreadOwnerEpoch::new(1),
+            durable_revision: DurableRevision::try_new(2).unwrap(),
+            commit_id: SurfaceCommitId::try_from_bytes(uuid_v7_bytes(15)).unwrap(),
+        };
+        let event = SurfaceEventEnvelope {
+            ordinal: 0,
+            event_id: SurfaceEventId::try_from_bytes(uuid_v7_bytes(16)).unwrap(),
+            commit_class: commit_class.clone(),
+            scope: SurfaceScope::Generation { fence },
+            event: SurfaceEvent::Assistant(AssistantPatch::ResponseCompleted {
+                response: SurfaceCompletedModelResponse {
+                    response_id: UuidV7::try_from_bytes(uuid_v7_bytes(17)).unwrap(),
+                    turn_id: turn_id.clone(),
+                    message_item: Some(SurfaceAssistantMessageItem {
+                        id: message_item_id,
+                        turn_id: turn_id.clone(),
+                        text: DisplayText::new("answer"),
+                        pinned: false,
+                    }),
+                    reasoning_item: Some(SurfaceAssistantReasoningItem {
+                        id: reasoning_item_id,
+                        turn_id,
+                        summary: DisplayText::new(""),
+                        content: DisplayText::new("reason"),
+                        pinned: false,
+                    }),
+                    plan_item: None,
+                    tool_calls: Vec::new(),
+                },
+            }),
+        };
+        let batch = SurfaceCommitBatch {
+            cursor_before: before.clone(),
+            cursor_after: SurfaceCursor {
+                next_seq: SequenceNumber::new(1),
+                source_revision: CursorSourceRevision::Recorded {
+                    durable_revision: DurableRevision::try_new(2).unwrap(),
+                },
+                ..before.clone()
+            },
+            commit_class,
+            event_count: 1,
+            batch_digest: Sha256Digest::new([0; 32]),
+            events: NonEmptyVec::try_new(vec![event]).unwrap(),
+        };
+        let mut projection =
+            TuiSurfaceProjection::from_snapshot(before, &[reasoning_stream, message_stream]);
+
+        assert!(projection.reduce_typed_batch(&batch).unwrap().is_empty());
+        assert!(
+            projection
+                .assistant_streams
+                .values()
+                .all(|stream| stream.state == SurfaceAssistantStreamState::Completed)
+        );
     }
 
     #[test]
@@ -1657,6 +1800,7 @@ mod tests {
         let mut projection = TuiSurfaceProjection {
             cursor: cursor(0, 1),
             assistant_streams: BTreeMap::new(),
+            assistant_stream_order: Vec::new(),
             completed_items: Vec::new(),
             operation_turn_ids: BTreeMap::new(),
             focused_operation: None,
@@ -1680,6 +1824,42 @@ mod tests {
             }] if id == "task-1" && status == "running"
         ));
         assert!(projection.hydrate_open_streams().is_empty());
+    }
+
+    #[test]
+    fn snapshot_hydration_preserves_assistant_stream_open_order() {
+        let fence = operation_fence(10);
+        let turn_id = SurfaceTurnId::new();
+        let reasoning = SurfaceAssistantStream {
+            stream_id: SurfaceStreamId::try_from_bytes(uuid_v7_bytes(31))
+                .expect("reasoning stream id"),
+            fence: fence.clone(),
+            turn_id: turn_id.clone(),
+            item_id: SurfaceItemId::new(),
+            channel: AssistantChannel::Reasoning,
+            next_offset: ByteOffset::new(6),
+            text: DisplayText::new("reason"),
+            state: SurfaceAssistantStreamState::Open,
+        };
+        let message = SurfaceAssistantStream {
+            stream_id: SurfaceStreamId::try_from_bytes(uuid_v7_bytes(30))
+                .expect("message stream id"),
+            fence,
+            turn_id,
+            item_id: SurfaceItemId::new(),
+            channel: AssistantChannel::Message,
+            next_offset: ByteOffset::new(6),
+            text: DisplayText::new("answer"),
+            state: SurfaceAssistantStreamState::Open,
+        };
+        let mut projection =
+            TuiSurfaceProjection::from_snapshot(cursor(0, 1), &[reasoning, message]);
+
+        assert!(matches!(
+            projection.hydrate_open_streams().as_slice(),
+            [TuiEvent::ReasoningDelta(reasoning), TuiEvent::MessageDelta(message)]
+                if reasoning == "reason" && message == "answer"
+        ));
     }
 
     #[test]
@@ -1761,6 +1941,47 @@ mod tests {
     }
 
     #[test]
+    fn foreground_hydration_preserves_assistant_stream_open_order() {
+        let fence = operation_fence(33);
+        let turn_id = SurfaceTurnId::new();
+        let reasoning = SurfaceAssistantStream {
+            stream_id: SurfaceStreamId::try_from_bytes(uuid_v7_bytes(35))
+                .expect("reasoning stream id"),
+            fence: fence.clone(),
+            turn_id: turn_id.clone(),
+            item_id: SurfaceItemId::new(),
+            channel: AssistantChannel::Reasoning,
+            next_offset: ByteOffset::new(6),
+            text: DisplayText::new("reason"),
+            state: SurfaceAssistantStreamState::Open,
+        };
+        let message = SurfaceAssistantStream {
+            stream_id: SurfaceStreamId::try_from_bytes(uuid_v7_bytes(34))
+                .expect("message stream id"),
+            fence: fence.clone(),
+            turn_id,
+            item_id: SurfaceItemId::new(),
+            channel: AssistantChannel::Message,
+            next_offset: ByteOffset::new(6),
+            text: DisplayText::new("answer"),
+            state: SurfaceAssistantStreamState::Open,
+        };
+        let projection = TuiSurfaceProjection::from_snapshot(cursor(0, 1), &[reasoning, message]);
+
+        assert!(matches!(
+            projection
+                .hydrate_after_delivery_watermark(
+                    &fence.operation_id,
+                    &TuiStreamDeliveryWatermark::new(),
+                )
+                .expect("valid delivery watermark")
+                .as_slice(),
+            [TuiEvent::ReasoningDelta(reasoning), TuiEvent::MessageDelta(message)]
+                if reasoning == "reason" && message == "answer"
+        ));
+    }
+
+    #[test]
     fn foreground_hydration_reconciles_completed_item_for_discarded_stream() {
         let fence = operation_fence(40);
         let turn_id = SurfaceTurnId::new();
@@ -1776,9 +1997,11 @@ mod tests {
             text: DisplayText::new("partial"),
             state: SurfaceAssistantStreamState::Discarded,
         };
+        let stream_id = stream.stream_id.clone();
         let projection = TuiSurfaceProjection {
             cursor: cursor(0, 1),
-            assistant_streams: BTreeMap::from([(stream.stream_id.clone(), stream)]),
+            assistant_streams: BTreeMap::from([(stream_id.clone(), stream)]),
+            assistant_stream_order: vec![stream_id],
             completed_items: vec![SurfaceItem::AssistantMessage {
                 id: item_id,
                 turn_id: turn_id.clone(),

--- a/crates/orca-tui/src/types.rs
+++ b/crates/orca-tui/src/types.rs
@@ -326,6 +326,7 @@ pub struct SurfaceProjectionState {
     pub(crate) title: String,
     pub(crate) usage_revision: u64,
     pub(crate) usage: UsageTotals,
+    pub(crate) context_revision: u64,
     pub(crate) context_used_tokens: usize,
     pub(crate) context_limit_tokens: usize,
     pub(crate) workflow_tasks: Vec<BackgroundTaskSummary>,
@@ -928,6 +929,11 @@ pub struct AppState {
     pub session_picker_error: Option<String>,
     pub usage: UsageTotals,
     usage_revision: Option<u64>,
+    /// Revision of the typed surface context snapshot last applied. Legacy
+    /// provider context events are transient and intentionally do not advance
+    /// this value, so an older snapshot cannot overwrite their observation.
+    context_revision: Option<u64>,
+    context_observed: bool,
     pub context_used_tokens: usize,
     pub context_limit_tokens: usize,
     pub slash_menu: Option<SlashMenu>,
@@ -1090,6 +1096,8 @@ impl AppState {
             session_picker_error: None,
             usage: UsageTotals::default(),
             usage_revision: None,
+            context_revision: None,
+            context_observed: false,
             context_used_tokens: 0,
             context_limit_tokens: 0,
             slash_menu: None,
@@ -1735,8 +1743,19 @@ impl AppState {
         self.current_session_title = Some(projection.title.clone());
         self.usage = projection.usage.clone();
         self.usage_revision = Some(projection.usage_revision);
-        self.context_used_tokens = projection.context_used_tokens;
-        self.context_limit_tokens = projection.context_limit_tokens;
+        let revision_advanced = self
+            .context_revision
+            .is_none_or(|revision| projection.context_revision > revision);
+        let should_apply_context =
+            revision_advanced && (!self.context_observed || self.context_revision.is_some());
+        if revision_advanced {
+            self.context_revision = Some(projection.context_revision);
+        }
+        if should_apply_context {
+            self.context_used_tokens = projection.context_used_tokens;
+            self.context_limit_tokens = projection.context_limit_tokens;
+            self.context_observed = false;
+        }
         self.current_goal = projection.current_goal.clone();
         self.active_surface_operation_id = projection.foreground_operation_id.clone();
         self.apply_workflow_tasks_update(projection.workflow_tasks.clone());
@@ -1754,8 +1773,11 @@ impl AppState {
         );
         debug_assert_eq!(self.usage, projection.usage);
         debug_assert_eq!(self.usage_revision, Some(projection.usage_revision));
-        debug_assert_eq!(self.context_used_tokens, projection.context_used_tokens);
-        debug_assert_eq!(self.context_limit_tokens, projection.context_limit_tokens);
+        if !self.context_observed {
+            debug_assert_eq!(self.context_revision, Some(projection.context_revision));
+            debug_assert_eq!(self.context_used_tokens, projection.context_used_tokens);
+            debug_assert_eq!(self.context_limit_tokens, projection.context_limit_tokens);
+        }
         debug_assert_eq!(
             self.workflow_panel.tasks,
             sort_workflow_tasks_for_panel(projection.workflow_tasks.clone())
@@ -1840,6 +1862,8 @@ impl AppState {
         self.usage_revision = None;
         self.context_used_tokens = 0;
         self.context_limit_tokens = 0;
+        self.context_revision = None;
+        self.context_observed = false;
         self.approval_dialog = None;
         self.pending_input = None;
         self.approval_allowlist.clear();
@@ -3134,6 +3158,7 @@ impl AppState {
             } => {
                 self.context_used_tokens = used_tokens;
                 self.context_limit_tokens = limit_tokens;
+                self.context_observed = true;
             }
             TuiEvent::CompactionStarted => {
                 self.set_status(AppStatus::Compacting);
@@ -5670,6 +5695,7 @@ mod tests {
                 cache_tokens: 7,
                 estimated_cost_usd: 0.007,
             },
+            context_revision: 1,
             context_used_tokens: 700,
             context_limit_tokens: 1_000,
             workflow_tasks: vec![workflow_task_summary("task-1", "Canonical task")],
@@ -5699,6 +5725,49 @@ mod tests {
             expected.foreground_operation_id
         );
         state.assert_surface_projection_consistent(&expected);
+
+        // A legacy provider usage event is more recent than the typed snapshot
+        // when the snapshot revision has not advanced. The stale snapshot must
+        // not put the footer back at 0%.
+        state.update(TuiEvent::ContextUpdated {
+            used_tokens: 25_000,
+            limit_tokens: 1_000_000,
+        });
+        state.update(TuiEvent::SurfaceProjectionSynced(Box::new(
+            expected.clone(),
+        )));
+        assert_eq!(state.context_used_tokens, 25_000);
+        assert_eq!(state.context_limit_tokens, 1_000_000);
+        state.assert_surface_projection_consistent(&expected);
+
+        let mut compacted = expected.clone();
+        compacted.context_revision = 2;
+        compacted.context_used_tokens = 10_000;
+        compacted.context_limit_tokens = 1_000_000;
+        state.update(TuiEvent::SurfaceProjectionSynced(Box::new(compacted)));
+        assert_eq!(state.context_used_tokens, 10_000);
+        assert_eq!(state.context_limit_tokens, 1_000_000);
+
+        let (pre_tx, _pre_rx) = mpsc::unbounded();
+        let mut pre_snapshot = AppState::new(
+            pre_tx,
+            "0.0.0-test".to_string(),
+            "mock".to_string(),
+            "/tmp".to_string(),
+        );
+        pre_snapshot.update(TuiEvent::ContextUpdated {
+            used_tokens: 30_000,
+            limit_tokens: 1_000_000,
+        });
+        pre_snapshot.update(TuiEvent::SurfaceProjectionSynced(Box::new(
+            expected.clone(),
+        )));
+        assert_eq!(pre_snapshot.context_used_tokens, 30_000);
+        let mut next_revision = expected.clone();
+        next_revision.context_revision = 2;
+        next_revision.context_used_tokens = 12_000;
+        pre_snapshot.update(TuiEvent::SurfaceProjectionSynced(Box::new(next_revision)));
+        assert_eq!(pre_snapshot.context_used_tokens, 12_000);
 
         let mut stale = expected.clone();
         stale.usage_revision = 6;

--- a/crates/orca-tui/src/ui.rs
+++ b/crates/orca-tui/src/ui.rs
@@ -4408,7 +4408,10 @@ fn truncate_lines(text: &str, max_lines: usize) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::types::{SlashMenu, SlashMenuItem, TuiEvent, TuiInteractionKey, TuiInteractionKind};
+    use crate::types::{
+        SlashMenu, SlashMenuItem, SurfaceProjectionState, TuiEvent, TuiInteractionKey,
+        TuiInteractionKind,
+    };
     use chrono::Utc;
     use crossbeam_channel as mpsc;
     use orca_core::config::{AdditionalWorkingDirectory, ThemeName};
@@ -6399,6 +6402,40 @@ mod tests {
         assert!(narrow.contains("context 25%"));
         assert!(!narrow.contains("git:"));
         assert!(!narrow.contains("blade-deepseek"));
+    }
+
+    #[test]
+    fn provider_context_survives_same_revision_surface_sync_in_footer() {
+        let mut state = test_state();
+        let snapshot = SurfaceProjectionState {
+            session_id: "goal-session".to_string(),
+            title: "Goal session".to_string(),
+            usage_revision: 1,
+            usage: orca_core::cost_types::UsageTotals::default(),
+            context_revision: 1,
+            context_used_tokens: 0,
+            context_limit_tokens: 128_000,
+            workflow_tasks: Vec::new(),
+            current_goal: None,
+            foreground_operation_id: None,
+        };
+        state.update(TuiEvent::SurfaceProjectionSynced(Box::new(
+            snapshot.clone(),
+        )));
+        state.update(TuiEvent::ContextUpdated {
+            used_tokens: 393_527,
+            limit_tokens: 1_000_000,
+        });
+
+        // A later operation batch carries the unchanged context snapshot.
+        state.update(TuiEvent::SurfaceProjectionSynced(Box::new(snapshot)));
+
+        let theme = Theme::named(orca_core::config::ThemeName::Dark);
+        assert!(
+            status_line(&state, &theme, 100)
+                .to_string()
+                .contains("context 39%")
+        );
     }
 
     #[test]

--- a/docs/harness-contract.md
+++ b/docs/harness-contract.md
@@ -319,7 +319,7 @@ Context window management:
 
 ### Replay State
 
-`provider.replay.updated` preserves provider-specific context for multi-turn DeepSeek thinking/tool-use flows (`reasoning_content` + tool call IDs). When DeepSeek returns reasoning with a tool call, the next request fully replays that reasoning alongside its assistant tool calls. If DeepSeek omits reasoning for a tool call, Orca executes the call without fabricating replay state.
+`provider.replay.updated` preserves provider-specific context for multi-turn DeepSeek thinking/tool-use flows (`reasoning_content` + tool call IDs). When DeepSeek returns reasoning with a tool call, the next request fully replays that reasoning alongside its assistant tool calls. If DeepSeek omits reasoning for a tool call, Orca executes the call without fabricating replay state. Recorded sessions also restore the latest provider prompt occupancy before a resumed turn; the TUI's typed context revision prevents an older snapshot from replacing a newer legacy context observation, and assistant stream hydration preserves stream-open order without duplicating an identical completed response.
 
 ## Configuration
 

--- a/docs/production-roadmap.md
+++ b/docs/production-roadmap.md
@@ -4,10 +4,11 @@
 > Reference implementations: Codex CLI, Claude Code, and the current Orca codebase.
 
 Last updated: 2026-08-06
-Current baseline: v0.3.6 adds explicit delegation-policy inheritance,
+Current baseline: v0.3.7 adds explicit delegation-policy inheritance,
 cross-process transcript write serialization, durable retry and truncation
-diagnostics, and full task-registry publication before session completion on
-headless and interactive surfaces on top of the native Windows x64 and ARM64 support across the
+diagnostics, context restoration with revision-safe TUI projection, ordered
+assistant stream replay, and full task-registry publication before session
+completion on headless and interactive surfaces on top of the native Windows x64 and ARM64 support across the
 CLI, TUI, shell sessions, sandboxing, update flow, persistence, npm packages,
 release archives, and CI. Shell resolution preserves PowerShell 7, Windows
 PowerShell, cmd.exe, and explicit Git Bash dialects. PowerShell 7 is discovered

--- a/docs/releases/v0.3.7.md
+++ b/docs/releases/v0.3.7.md
@@ -1,0 +1,57 @@
+# Orca v0.3.7
+
+Orca v0.3.7 completes the session-context and TUI projection reliability
+slice on top of v0.3.6's delegated execution and durable task-state work.
+
+## What Changed
+
+- Recorded sessions restore the latest provider prompt occupancy before the
+  first resumed turn. The context limit is derived from the configured model
+  window, while legacy usage records remain readable.
+- The TUI carries a typed context revision and does not let an older surface
+  snapshot overwrite a newer provider context observation. The context footer
+  therefore remains accurate while the next durable surface batch arrives.
+- Assistant reasoning, message, and plan streams retain their opened order
+  during snapshot and foreground hydration. A completed response that exactly
+  matches already streamed items is not projected a second time.
+- Existing v0.3.6 behavior remains included: delegated child agents inherit
+  one immutable policy snapshot; transcript appends and rewrites share a
+  cross-process lock; retry and truncation diagnostics remain in task state;
+  and session completion publishes the complete task registry first.
+
+## Compatibility
+
+Saved transcripts with older usage records remain readable. New context
+revision and projection fields are runtime-internal and do not change CLI,
+JSONL, app-server, ACP, provider, or task identifier contracts.
+
+## Verification
+
+- `cargo fmt --all -- --check`
+- `cargo check --workspace --all-targets --locked`
+- Focused runtime and TUI tests for resumed context, repeated usage snapshots,
+  revision-safe projection, assistant stream ordering, and duplicate response
+  suppression
+- `cargo nextest run --workspace --all-targets --locked --profile ci --no-fail-fast`
+- Runtime surface, repository adapter, version synchronization, npm staging,
+  website build, SEO, and published-release verification gates
+- `git diff --check`
+
+## Upgrade
+
+```bash
+npm install -g @blade-ai/orca@0.3.7
+```
+
+macOS and Linux native installer:
+
+```bash
+curl -fsSL https://orcaagent.dev/install.sh | \
+  INSTALL_DIR=/usr/local/bin ORCA_VERSION=0.3.7 sh
+```
+
+Windows PowerShell, including workspace sandbox setup:
+
+```powershell
+& ([scriptblock]::Create((irm https://orcaagent.dev/install.ps1))) -Version 0.3.7 -SetupSandbox
+```

--- a/npm/orca/package.json
+++ b/npm/orca/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@blade-ai/orca",
-  "version": "0.3.6",
+  "version": "0.3.7",
   "description": "Orca CLI: a DeepSeek-native coding agent.",
   "homepage": "https://orcaagent.dev/",
   "license": "MIT",

--- a/site/src/changelog/Changelog.tsx
+++ b/site/src/changelog/Changelog.tsx
@@ -76,6 +76,8 @@ const copy = {
       ],
     },
     summaries: {
+      "v0.3.7":
+        "Completes session-context and TUI projection reliability. Recorded sessions restore provider prompt occupancy before the first resumed turn; revision-aware projection prevents an older surface snapshot from replacing a newer context footer; reasoning, message, and plan streams preserve their opened order during hydration; and already-streamed completed responses are no longer rendered twice. The delegated execution, transcript locking, retry diagnostics, and task-registry guarantees from v0.3.6 remain included.",
       "v0.3.6":
         "Strengthens runtime reliability across delegated work and durable task state. Synchronous, asynchronous, and workflow child agents now inherit one serialized execution-policy snapshot; plaintext and compressed transcript paths share a stable cross-process lock during append and rewrite; provider compaction retries and truncated tool output remain visible in task summaries; and session completion publishes the complete task registry before the terminal event. The composer remains available while an activity line shows running or approval-blocked background work.",
       "v0.3.5":
@@ -570,6 +572,8 @@ const copy = {
       ],
     },
     summaries: {
+      "v0.3.7":
+        "完成 session context 与 TUI projection reliability 收口。恢复历史会话时会在首个 resumed turn 前还原 provider prompt 占用；revision-aware projection 不会让旧 surface snapshot 覆盖更新的 context footer；reasoning、message、plan stream 在 hydration 时保留打开顺序；已经流式展示的 completed response 不会再渲染一遍。v0.3.6 的 delegated execution、transcript lock、retry diagnostics 与 task registry 保证继续包含在本版本中。",
       "v0.3.6":
         "增强 runtime reliability，统一 delegated work 与 durable task 状态。同步、异步和 workflow 子 agent 现在继承同一份序列化执行策略快照；同一 thread transcript 的明文与压缩路径在 append 和 rewrite 时共用稳定的跨进程锁；provider 压缩重试与被截断的 tool 输出会保留在任务摘要中；session 完成事件前会先发布完整 task registry。前台 composer 仍可继续使用，activity line 会持续展示运行中或等待审批的后台任务。",
       "v0.3.5":

--- a/site/src/shared.ts
+++ b/site/src/shared.ts
@@ -4,9 +4,14 @@ export const localeStorageKey = "orca-site-locale";
 export const canonicalOrigin = "https://orcaagent.dev";
 export const socialImageUrl = `${canonicalOrigin}/orca-social.png`;
 
-export const releaseVersion = "v0.3.6";
+export const releaseVersion = "v0.3.7";
 
 export const releases = [
+  {
+    version: "v0.3.7",
+    date: "2026-08-06",
+    url: "https://github.com/echoVic/orca-agent/releases/tag/v0.3.7",
+  },
   {
     version: "v0.3.6",
     date: "2026-08-06",


### PR DESCRIPTION
# Orca v0.3.7

Orca v0.3.7 completes the session-context and TUI projection reliability
slice on top of v0.3.6's delegated execution and durable task-state work.

## What Changed

- Recorded sessions restore the latest provider prompt occupancy before the
  first resumed turn. The context limit is derived from the configured model
  window, while legacy usage records remain readable.
- The TUI carries a typed context revision and does not let an older surface
  snapshot overwrite a newer provider context observation. The context footer
  therefore remains accurate while the next durable surface batch arrives.
- Assistant reasoning, message, and plan streams retain their opened order
  during snapshot and foreground hydration. A completed response that exactly
  matches already streamed items is not projected a second time.
- Existing v0.3.6 behavior remains included: delegated child agents inherit
  one immutable policy snapshot; transcript appends and rewrites share a
  cross-process lock; retry and truncation diagnostics remain in task state;
  and session completion publishes the complete task registry first.

## Compatibility

Saved transcripts with older usage records remain readable. New context
revision and projection fields are runtime-internal and do not change CLI,
JSONL, app-server, ACP, provider, or task identifier contracts.

## Verification

- `cargo fmt --all -- --check`
- `cargo check --workspace --all-targets --locked`
- Focused runtime and TUI tests for resumed context, repeated usage snapshots,
  revision-safe projection, assistant stream ordering, and duplicate response
  suppression
- `cargo nextest run --workspace --all-targets --locked --profile ci --no-fail-fast`
- Runtime surface, repository adapter, version synchronization, npm staging,
  website build, SEO, and published-release verification gates
- `git diff --check`

## Upgrade

```bash
npm install -g @blade-ai/orca@0.3.7
```

macOS and Linux native installer:

```bash
curl -fsSL https://orcaagent.dev/install.sh | \
  INSTALL_DIR=/usr/local/bin ORCA_VERSION=0.3.7 sh
```

Windows PowerShell, including workspace sandbox setup:

```powershell
& ([scriptblock]::Create((irm https://orcaagent.dev/install.ps1))) -Version 0.3.7 -SetupSandbox
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Restored provider context usage when resuming recorded sessions.
  * Preserved assistant stream order during session replay.
  * Prevented duplicate completion events in streamed responses.
  * Improved context updates by ignoring stale projection data.

* **Bug Fixes**
  * Fixed resumed sessions displaying incorrect context limits or usage.
  * Fixed newer context information being overwritten by older updates.

* **Documentation**
  * Added v0.3.7 release notes and updated product documentation and changelogs.

* **Release**
  * Updated the application and package version to v0.3.7.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->