### PR TITLE
ci(npm): tolerate transient dist-tag cleanup failure

### DIFF
--- a/.github/workflows/npm-token-check.yml
+++ b/.github/workflows/npm-token-check.yml
@@ -33,4 +33,5 @@ jobs:
 
           npm dist-tag add "${PACKAGE_NAME}@${PACKAGE_VERSION}" "$TEST_TAG"
           npm dist-tag ls "$PACKAGE_NAME"
-          npm dist-tag rm "$PACKAGE_NAME" "$TEST_TAG"
+          npm dist-tag rm "$PACKAGE_NAME" "$TEST_TAG" \
+            || echo "::warning::temporary dist-tag cleanup will be retried by the EXIT trap"


### PR DESCRIPTION
## Summary
- keep npm identity and dist-tag write checks blocking
- downgrade the explicit temporary dist-tag cleanup failure to a warning
- retain the EXIT trap as a best-effort cleanup retry

## Validation
- YAML syntax validation passed
- `git diff --check` passed
- npm token checks confirmed identity and write access; only DELETE intermittently returns 403

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved workflow reporting by displaying a warning when temporary npm dist-tag cleanup fails.
  * Retained automatic retry behavior for cleanup operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->