### PR TITLE
release: prepare v0.3.26

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -204,7 +204,7 @@ checksum = "84d7ced0ae9557296835c32bf1b1e02b44c746701f898460fb000d7eaa84f00a"
 
 [[package]]
 name = "blade-deepseek"
-version = "0.3.25"
+version = "0.3.26"
 dependencies = [
  "base64",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,7 +48,7 @@ windows-sys = "0.61"
 
 [package]
 name = "blade-deepseek"
-version = "0.3.25"
+version = "0.3.26"
 edition = "2024"
 description = "Orca: a DeepSeek-native coding agent"
 license = "MIT"

--- a/crates/orca-runtime/src/controller.rs
+++ b/crates/orca-runtime/src/controller.rs
@@ -211,6 +211,7 @@ pub struct ThreadTurnContext<'a> {
     prompt: String,
     memory_start: usize,
     parts: InteractiveSessionRuntimeParts<'a>,
+    unsandboxed_shell: bool,
 }
 
 pub struct ThreadTurnExecution<W: io::Write> {
@@ -501,6 +502,7 @@ impl<'a> ThreadTurnContext<'a> {
             cwd,
             prompt,
             memory_start,
+            unsandboxed_shell: parts.unsandboxed_shell,
             parts,
         })
     }
@@ -699,6 +701,7 @@ impl<'a, 'session, W: io::Write> PreparedThreadTurn<'a, 'session, W> {
             cwd,
             prompt,
             memory_start,
+            unsandboxed_shell,
             parts,
         } = context;
         let main_session_task = ThreadTurnMainSessionTask::from_request(
@@ -749,6 +752,7 @@ impl<'a, 'session, W: io::Write> PreparedThreadTurn<'a, 'session, W> {
         .with_provider_response_ingress(request.provider_response_ingress())
         .with_workflow_lifecycle_ingress(request.workflow_lifecycle_ingress())
         .with_wait_for_background_workflows(request.options().wait_for_background_workflows);
+        let loop_context = loop_context.with_unsandboxed_shell(unsandboxed_shell);
         let turn_result = (|| -> io::Result<AgentLoopOutcome> {
             run_agent_loop(
                 config,

--- a/crates/orca-runtime/src/history.rs
+++ b/crates/orca-runtime/src/history.rs
@@ -436,6 +436,7 @@ pub fn create_meta(cwd: &Path, provider: &str, model: Option<String>, prompt: &s
         additional_working_directories: Vec::new(),
         metadata_writable_directories: Vec::new(),
         network_domain_permissions: Default::default(),
+        unsandboxed_shell: false,
     }
 }
 

--- a/crates/orca-runtime/src/lifecycle.rs
+++ b/crates/orca-runtime/src/lifecycle.rs
@@ -231,6 +231,7 @@ pub(crate) struct RuntimeTurnContext<'a> {
     pub(crate) workflow_lifecycle_ingress: Option<&'a dyn RuntimeWorkflowLifecycleIngress>,
     pub(crate) wait_for_background_workflows: bool,
     pub(crate) defer_cancel_terminal: bool,
+    pub(crate) unsandboxed_shell: bool,
 }
 
 #[derive(Clone, Copy)]
@@ -944,6 +945,11 @@ impl<'a> AgentLoopContext<'a> {
         self
     }
 
+    pub(crate) fn with_unsandboxed_shell(mut self, enabled: bool) -> Self {
+        self.turn_context = self.turn_context.with_unsandboxed_shell(enabled);
+        self
+    }
+
     pub fn with_turn_id(mut self, turn_id: TurnId) -> Self {
         self.turn_context = self.turn_context.with_turn_id(turn_id);
         self
@@ -1204,6 +1210,7 @@ impl<'a> RuntimeTurnContext<'a> {
             workflow_lifecycle_ingress: None,
             wait_for_background_workflows: true,
             defer_cancel_terminal: false,
+            unsandboxed_shell: false,
         }
     }
 
@@ -1271,6 +1278,15 @@ impl<'a> RuntimeTurnContext<'a> {
     pub(crate) fn with_deferred_cancel_terminal(mut self, defer: bool) -> Self {
         self.defer_cancel_terminal = defer;
         self
+    }
+
+    pub(crate) fn with_unsandboxed_shell(mut self, enabled: bool) -> Self {
+        self.unsandboxed_shell = enabled;
+        self
+    }
+
+    pub(crate) fn unsandboxed_shell(&self) -> bool {
+        self.unsandboxed_shell
     }
 
     #[cfg(test)]

--- a/crates/orca-runtime/src/provider_turn.rs
+++ b/crates/orca-runtime/src/provider_turn.rs
@@ -804,6 +804,7 @@ impl RuntimeTurnProviderCycleStep {
             input.conversation.parts_mut_with_checkpoint_observer();
         let mut kernel = RuntimeTurnKernel::from_extension_stores(input.extensions.stores());
         kernel.set_preapproved_tool_call_id(preapproved_tool_call_id);
+        kernel.set_unsandboxed_shell(input.turn_context.unsandboxed_shell());
         let step_context =
             RuntimeStepContext::from_snapshot(RuntimeStepSnapshot::new_with_capabilities(
                 input.config,

--- a/crates/orca-runtime/src/runtime_bash.rs
+++ b/crates/orca-runtime/src/runtime_bash.rs
@@ -83,6 +83,25 @@ pub(crate) fn execute_bash_with_shell_session(
         })
         .into_tool_result(request, output_truncation, shell_timeout_secs);
     };
+    if permission_overlay.unsandboxed_shell() {
+        return execute_bash_once(RuntimeBashOnceContext {
+            command,
+            cwd,
+            additional_readable_directories: Vec::new(),
+            additional_working_directories: additional_roots.to_vec(),
+            metadata_writable_directories: Vec::new(),
+            denied_working_directories: Vec::new(),
+            allowed_unix_socket_roots: Vec::new(),
+            env: Default::default(),
+            sandbox: ShellSandboxMode::DangerFullAccess,
+            shell_timeout_secs,
+            task_registry,
+            cancel,
+            output_handler: reborrow_output_handler(&mut output_handler),
+        })
+        .with_sandbox_diagnostic(cwd)
+        .into_tool_result(request, output_truncation, shell_timeout_secs);
+    }
     let mut sandbox = match bash_sandbox_from_active_permission_profile(config, cwd) {
         Ok(sandbox) => sandbox,
         Err(error) => return ToolResult::failed(request, error, None),
@@ -202,46 +221,49 @@ pub(crate) fn execute_bash_with_shell_session(
             .with_sandbox_diagnostic(cwd)
             .into_tool_result(request, output_truncation, shell_timeout_secs);
         }
-        if let Some(permission_prompt) =
-            RuntimeBashPermissionPolicy::unsandboxed_shell_prompt(&request.id, &diagnostic)
-            && let Some(permission_handler) = permission_handler
-        {
-            let (_origin, _kind, permission_request) = permission_prompt.into_request_parts();
-            let response = match PermissionRuntimeState.request_permission_pre_side_effect(
-                permission_overlay,
-                permission_handler,
-                permission_request,
-            ) {
-                Ok(response) => response,
-                Err(error) => return ToolResult::failed(request, error.to_string(), None),
-            };
-            if response.decision == PermissionResponseDecision::Deny {
-                return ToolResult::denied(request, "permission request denied".to_string());
+        if !permission_overlay.unsandboxed_shell() {
+            if let Some(permission_prompt) =
+                RuntimeBashPermissionPolicy::unsandboxed_shell_prompt(&request.id, &diagnostic)
+                && let Some(permission_handler) = permission_handler
+            {
+                let (_origin, _kind, permission_request) = permission_prompt.into_request_parts();
+                let response = match PermissionRuntimeState.request_permission_pre_side_effect(
+                    permission_overlay,
+                    permission_handler,
+                    permission_request,
+                ) {
+                    Ok(response) => response,
+                    Err(error) => return ToolResult::failed(request, error.to_string(), None),
+                };
+                if response.decision == PermissionResponseDecision::Deny {
+                    return ToolResult::denied(request, "permission request denied".to_string());
+                }
+            } else {
+                return output.with_diagnostic(diagnostic).into_tool_result(
+                    request,
+                    output_truncation,
+                    shell_timeout_secs,
+                );
             }
-
-            return execute_bash_once(RuntimeBashOnceContext {
-                command,
-                cwd,
-                additional_readable_directories: Vec::new(),
-                additional_working_directories: additional_roots.to_vec(),
-                metadata_writable_directories: Vec::new(),
-                denied_working_directories: Vec::new(),
-                allowed_unix_socket_roots: Vec::new(),
-                env: Default::default(),
-                sandbox: ShellSandboxMode::DangerFullAccess,
-                shell_timeout_secs,
-                task_registry,
-                cancel,
-                output_handler: reborrow_output_handler(&mut output_handler),
-            })
-            .with_sandbox_diagnostic(cwd)
-            .into_tool_result(request, output_truncation, shell_timeout_secs);
         }
-        return output.with_diagnostic(diagnostic).into_tool_result(
-            request,
-            output_truncation,
+
+        return execute_bash_once(RuntimeBashOnceContext {
+            command,
+            cwd,
+            additional_readable_directories: Vec::new(),
+            additional_working_directories: additional_roots.to_vec(),
+            metadata_writable_directories: Vec::new(),
+            denied_working_directories: Vec::new(),
+            allowed_unix_socket_roots: Vec::new(),
+            env: Default::default(),
+            sandbox: ShellSandboxMode::DangerFullAccess,
             shell_timeout_secs,
-        );
+            task_registry,
+            cancel,
+            output_handler: reborrow_output_handler(&mut output_handler),
+        })
+        .with_sandbox_diagnostic(cwd)
+        .into_tool_result(request, output_truncation, shell_timeout_secs);
     }
     output.into_tool_result(request, output_truncation, shell_timeout_secs)
 }

--- a/crates/orca-runtime/src/runtime_host.rs
+++ b/crates/orca-runtime/src/runtime_host.rs
@@ -9715,7 +9715,7 @@ fn bootstrap_recorded_surface(
     let owner_lease = surface_owner.owner_lease;
     let current_owner_epoch = surface::ThreadOwnerEpoch::new(owner_lease.owner_epoch());
     let initial_owner_epoch = current_owner_epoch.get().saturating_sub(1).max(1);
-    let snapshot = initial_surface_snapshot(
+    let mut snapshot = initial_surface_snapshot(
         thread_id,
         incarnation,
         surface::ThreadOwnerEpoch::new(initial_owner_epoch),
@@ -9724,6 +9724,7 @@ fn bootstrap_recorded_surface(
         title,
         restored_context_tokens,
     )?;
+    snapshot.settings.effective.unsandboxed_shell = thread.session().unsandboxed_shell();
     let ledger = surface::JsonlSurfaceCommitLedger::new(path, snapshot.cursor.clone());
     let mut coordinator = surface::RuntimeCommitCoordinator::recover_with_owned_lease(
         ledger,
@@ -10310,6 +10311,7 @@ fn initial_surface_snapshot(
             enabled: None,
             domains: Vec::new(),
         },
+        unsandboxed_shell: false,
         policy_epoch: surface::PolicyEpoch::try_new(1).expect("one is a valid revision"),
     };
     let source_revision = match &persistence {
@@ -10513,6 +10515,12 @@ fn apply_runtime_settings_patch(
         surface::RuntimeSettingsPatch::ReplaceNetworkPermissions { permissions } => {
             settings.network_permissions = permissions.clone();
         }
+        surface::RuntimeSettingsPatch::SetUnsandboxedShell { enabled } => {
+            if !*enabled && settings.unsandboxed_shell {
+                return Err(surface::SurfaceClientCommandError::Unauthorized);
+            }
+            settings.unsandboxed_shell = *enabled;
+        }
         surface::RuntimeSettingsPatch::ApplyPermissionUpdate { .. } => {
             return Err(surface::SurfaceClientCommandError::Unauthorized);
         }
@@ -10530,6 +10538,7 @@ fn runtime_settings_patch_affects_policy(patch: &surface::RuntimeSettingsPatch) 
             | surface::RuntimeSettingsPatch::ReplacePermissionRules { .. }
             | surface::RuntimeSettingsPatch::ReplaceAdditionalWorkingDirectories { .. }
             | surface::RuntimeSettingsPatch::ReplaceNetworkPermissions { .. }
+            | surface::RuntimeSettingsPatch::SetUnsandboxedShell { .. }
             | surface::RuntimeSettingsPatch::ApplyPermissionUpdate { .. }
     )
 }
@@ -10683,6 +10692,7 @@ fn persist_surface_settings_metadata(
                 ),
                 metadata_writable_directories: None,
                 network_domain_permissions: Some(network_domain_permissions),
+                unsandboxed_shell: Some(settings.unsandboxed_shell),
             },
         )
         .map(|_| ())
@@ -12853,6 +12863,7 @@ fn surface_permission_retry_overlay_from_runtime(
         additional_working_directories,
         metadata_writable_directories,
         network_domain_permissions,
+        unsandboxed_shell: overlay.unsandboxed_shell(),
         strict_auto_review: overlay.strict_auto_review(),
     })
 }
@@ -12894,7 +12905,9 @@ fn runtime_permission_overlay_from_surface(
                 })
                 .collect(),
         }),
-        shell: None,
+        shell: overlay
+            .unsandboxed_shell
+            .then_some(crate::protocol::RequestShellPermissions { unsandboxed: true }),
     };
     runtime.merge_permissions(&permissions);
     runtime.merge_strict_auto_review(overlay.strict_auto_review);
@@ -13002,7 +13015,7 @@ fn surface_session_permission_grant_is_applied(
     let shell_applied = permissions
         .shell
         .as_ref()
-        .is_none_or(|shell| !shell.unsandboxed);
+        .is_none_or(|shell| !shell.unsandboxed || settings.unsandboxed_shell);
     paths_applied && network_applied && shell_applied
 }
 
@@ -13018,6 +13031,7 @@ fn surface_session_permission_settings_delta_authorized(
         || current.workspace_roots != next.workspace_roots
         || current.active_permission_profile != next.active_permission_profile
         || current.permission_rules != next.permission_rules
+        || (current.unsandboxed_shell && !next.unsandboxed_shell)
     {
         return false;
     }
@@ -13055,6 +13069,15 @@ fn surface_session_permission_settings_delta_authorized(
     let requested_network = requested.network.as_ref();
     if current.network_permissions.enabled != next.network_permissions.enabled
         && requested_network.and_then(|network| network.enabled) != next.network_permissions.enabled
+    {
+        return false;
+    }
+    if current.unsandboxed_shell != next.unsandboxed_shell
+        && (!next.unsandboxed_shell
+            || !requested
+                .shell
+                .as_ref()
+                .is_some_and(|shell| shell.unsandboxed))
     {
         return false;
     }
@@ -27837,6 +27860,11 @@ impl ThreadActor {
                     self.commit_surface_actor_batch_with_retry(&settings_batch)
                         .map_err(|_| surface::SurfaceClientCommandError::RuntimeUnavailable)?;
                     self.config = next_config;
+                    if next_settings.effective.unsandboxed_shell {
+                        if let Some(state) = self.state.as_mut() {
+                            state.thread.session_mut().set_unsandboxed_shell(true);
+                        }
+                    }
                     self.persist_surface_settings_metadata_if_recorded(&next_settings.effective)
                         .map_err(|_| surface::SurfaceClientCommandError::RuntimeUnavailable)?;
                     let receipt =
@@ -29653,6 +29681,11 @@ impl ThreadActor {
             }
         }
         self.config = next_config;
+        if next_settings.effective.unsandboxed_shell {
+            if let Some(state) = self.state.as_mut() {
+                state.thread.session_mut().set_unsandboxed_shell(true);
+            }
+        }
         self.persist_surface_settings_metadata_if_recorded(&next_settings.effective)
             .map_err(|_| surface::SurfaceClientCommandError::RuntimeUnavailable)?;
         Ok(self.committed_settings_mutation(

--- a/crates/orca-runtime/src/runtime_permission.rs
+++ b/crates/orca-runtime/src/runtime_permission.rs
@@ -272,6 +272,7 @@ pub struct TurnPermissionOverlay {
     metadata_writable_directories: Vec<PathBuf>,
     network_domain_permissions:
         std::collections::HashMap<String, orca_core::config::PermissionProfileNetworkAccess>,
+    unsandboxed_shell: bool,
     strict_auto_review: bool,
     preapproved_tool_call_id: Option<String>,
 }
@@ -282,6 +283,7 @@ pub struct TurnPermissionOverlayDelta {
     metadata_writable_directories: Vec<PathBuf>,
     network_domain_permissions:
         std::collections::HashMap<String, orca_core::config::PermissionProfileNetworkAccess>,
+    unsandboxed_shell: bool,
     strict_auto_review: bool,
 }
 
@@ -303,6 +305,10 @@ impl TurnPermissionOverlayDelta {
     pub fn strict_auto_review(&self) -> bool {
         self.strict_auto_review
     }
+
+    pub fn unsandboxed_shell(&self) -> bool {
+        self.unsandboxed_shell
+    }
 }
 
 impl TurnPermissionOverlay {
@@ -322,6 +328,10 @@ impl TurnPermissionOverlay {
 
     pub fn strict_auto_review(&self) -> bool {
         self.strict_auto_review
+    }
+
+    pub fn unsandboxed_shell(&self) -> bool {
+        self.unsandboxed_shell
     }
 
     pub(crate) fn set_preapproved_tool_call_id(&mut self, id: Option<String>) {
@@ -351,6 +361,7 @@ impl TurnPermissionOverlay {
             self.network_domain_permissions
                 .insert(domain.clone(), *access);
         }
+        self.unsandboxed_shell |= other.unsandboxed_shell;
         self.strict_auto_review |= other.strict_auto_review;
     }
 
@@ -379,6 +390,7 @@ impl TurnPermissionOverlay {
             additional_working_directories,
             metadata_writable_directories,
             network_domain_permissions,
+            unsandboxed_shell: self.unsandboxed_shell && !baseline.unsandboxed_shell,
             strict_auto_review: self.strict_auto_review && !baseline.strict_auto_review,
         }
     }
@@ -398,6 +410,7 @@ impl TurnPermissionOverlay {
             self.network_domain_permissions
                 .insert(domain.clone(), *access);
         }
+        self.unsandboxed_shell |= delta.unsandboxed_shell;
         self.strict_auto_review |= delta.strict_auto_review;
     }
 
@@ -467,6 +480,13 @@ impl TurnPermissionOverlay {
             }
         }
         self.merge_network_permissions(permissions);
+        if permissions
+            .shell
+            .as_ref()
+            .is_some_and(|shell| shell.unsandboxed)
+        {
+            self.unsandboxed_shell = true;
+        }
     }
 }
 
@@ -502,6 +522,49 @@ mod tests {
         assert!(!overlay.consume_preapproved_tool_call_id("tool-2"));
         assert!(overlay.consume_preapproved_tool_call_id("tool-1"));
         assert!(!overlay.consume_preapproved_tool_call_id("tool-1"));
+    }
+
+    #[test]
+    fn shell_capability_is_reusable_and_survives_permission_delta() {
+        let mut overlay = TurnPermissionOverlay::default();
+        overlay.merge_permissions(&RequestPermissionProfile {
+            shell: Some(crate::protocol::RequestShellPermissions { unsandboxed: true }),
+            ..Default::default()
+        });
+
+        assert!(overlay.unsandboxed_shell());
+
+        let baseline = TurnPermissionOverlay::default();
+        let delta = overlay.delta_from(&baseline);
+        assert!(delta.unsandboxed_shell());
+
+        let mut restored = baseline;
+        restored.apply_delta(&delta);
+        assert!(restored.unsandboxed_shell());
+        assert_eq!(restored.preapproved_tool_call_id, None);
+    }
+
+    #[test]
+    fn unrelated_permission_delta_does_not_grant_unsandboxed_shell() {
+        let baseline = TurnPermissionOverlay::default();
+        let mut current = baseline.clone();
+        current.merge_permissions(&RequestPermissionProfile {
+            network: Some(crate::protocol::RequestNetworkPermissions {
+                enabled: None,
+                domains: HashMap::from([(
+                    "api.example.com".to_string(),
+                    PermissionProfileNetworkAccess::Allow,
+                )]),
+            }),
+            ..Default::default()
+        });
+
+        let delta = current.delta_from(&baseline);
+        assert!(!delta.unsandboxed_shell());
+
+        let mut restored = baseline;
+        restored.apply_delta(&delta);
+        assert!(!restored.unsandboxed_shell());
     }
 
     #[test]
@@ -545,6 +608,7 @@ mod tests {
                 "api.example.com".to_string(),
                 PermissionProfileNetworkAccess::Allow,
             )]),
+            unsandboxed_shell: false,
             strict_auto_review: false,
             preapproved_tool_call_id: Some("approval-only".to_string()),
         };
@@ -564,6 +628,7 @@ mod tests {
                     PermissionProfileNetworkAccess::Deny,
                 ),
             ]),
+            unsandboxed_shell: false,
             strict_auto_review: true,
             preapproved_tool_call_id: None,
         };

--- a/crates/orca-runtime/src/runtime_surface/commands.rs
+++ b/crates/orca-runtime/src/runtime_surface/commands.rs
@@ -4460,6 +4460,7 @@ mod closed_command_domain_tests {
                 enabled: Some(true),
                 domains: Vec::new(),
             },
+            unsandboxed_shell: false,
             policy_epoch: PolicyEpoch::try_new(1).unwrap(),
         }
     }

--- a/crates/orca-runtime/src/runtime_surface/interaction.rs
+++ b/crates/orca-runtime/src/runtime_surface/interaction.rs
@@ -596,6 +596,8 @@ pub(crate) struct PermissionRetryOverlay {
     pub additional_working_directories: Vec<CanonicalPath>,
     pub metadata_writable_directories: Vec<CanonicalPath>,
     pub network_domain_permissions: Vec<(SurfacePermissionDomainPattern, SurfaceAllowDeny)>,
+    #[serde(default)]
+    pub unsandboxed_shell: bool,
     pub strict_auto_review: bool,
 }
 
@@ -605,6 +607,7 @@ impl PermissionRetryOverlay {
             additional_working_directories: Vec::new(),
             metadata_writable_directories: Vec::new(),
             network_domain_permissions: Vec::new(),
+            unsandboxed_shell: false,
             strict_auto_review: false,
         }
     }

--- a/crates/orca-runtime/src/runtime_surface/operation.rs
+++ b/crates/orca-runtime/src/runtime_surface/operation.rs
@@ -1020,6 +1020,8 @@ pub struct SurfaceRuntimeSettings {
     pub permission_rules: SurfacePermissionRuleSet,
     pub additional_working_directories: Vec<SurfaceAdditionalWorkingDirectory>,
     pub network_permissions: SurfaceNetworkPermissions,
+    #[serde(default)]
+    pub unsandboxed_shell: bool,
     pub policy_epoch: PolicyEpoch,
 }
 
@@ -1096,6 +1098,9 @@ pub enum RuntimeSettingsPatch {
     },
     ReplaceNetworkPermissions {
         permissions: SurfaceNetworkPermissions,
+    },
+    SetUnsandboxedShell {
+        enabled: bool,
     },
     ApplyPermissionUpdate {
         update: SurfacePermissionUpdate,

--- a/crates/orca-runtime/src/runtime_surface/reducer.rs
+++ b/crates/orca-runtime/src/runtime_surface/reducer.rs
@@ -8535,6 +8535,7 @@ pub(crate) mod tests {
                         enabled: Some(true),
                         domains: Vec::new(),
                     },
+                    unsandboxed_shell: false,
                     policy_epoch: PolicyEpoch::try_new(1).unwrap(),
                 },
                 pending: None,

--- a/crates/orca-runtime/src/runtime_turn_kernel.rs
+++ b/crates/orca-runtime/src/runtime_turn_kernel.rs
@@ -49,6 +49,17 @@ impl<'a> RuntimeTurnKernel<'a> {
             .set_preapproved_tool_call_id(id);
     }
 
+    pub(crate) fn set_unsandboxed_shell(&mut self, enabled: bool) {
+        if enabled {
+            self.sampling_state
+                .permission_overlay_mut()
+                .merge_permissions(&crate::protocol::RequestPermissionProfile {
+                    shell: Some(crate::protocol::RequestShellPermissions { unsandboxed: true }),
+                    ..Default::default()
+                });
+        }
+    }
+
     #[cfg(test)]
     #[allow(dead_code)]
     pub(crate) fn bind_step_context(

--- a/crates/orca-runtime/src/runtime_turn_loop.rs
+++ b/crates/orca-runtime/src/runtime_turn_loop.rs
@@ -201,6 +201,7 @@ impl<'a> RuntimeTurnRequestContext<'a> {
             workflow_lifecycle_ingress: self.turn_context.workflow_lifecycle_ingress,
             wait_for_background_workflows: self.turn_context.wait_for_background_workflows,
             defer_cancel_terminal: self.turn_context.defer_cancel_terminal,
+            unsandboxed_shell: self.turn_context.unsandboxed_shell,
         };
         Self { turn_context }
     }

--- a/crates/orca-runtime/src/server.rs
+++ b/crates/orca-runtime/src/server.rs
@@ -161,6 +161,7 @@ pub struct ServerThreadView {
     additional_working_directories: Vec<AdditionalWorkingDirectory>,
     metadata_writable_directories: Vec<PathBuf>,
     network_domain_permissions: HashMap<String, PermissionProfileNetworkAccess>,
+    unsandboxed_shell: bool,
     mcp_registry: McpRegistry,
 }
 
@@ -183,6 +184,10 @@ impl ServerThreadView {
 
     pub fn network_domain_permissions(&self) -> &HashMap<String, PermissionProfileNetworkAccess> {
         &self.network_domain_permissions
+    }
+
+    pub fn unsandboxed_shell(&self) -> bool {
+        self.unsandboxed_shell
     }
 
     pub fn cwd(&self) -> &str {
@@ -770,6 +775,7 @@ struct PersistedSessionPermissionGrant {
     additional_working_directories: Vec<orca_core::config::AdditionalWorkingDirectory>,
     metadata_writable_directories: Vec<PathBuf>,
     network_domain_permissions: HashMap<String, orca_core::config::PermissionProfileNetworkAccess>,
+    unsandboxed_shell: bool,
 }
 
 fn push_unique_path(paths: &mut Vec<PathBuf>, path: PathBuf) {
@@ -816,6 +822,10 @@ fn materialize_session_permission_grant(
         additional_working_directories: thread.additional_working_directories,
         metadata_writable_directories: thread.metadata_writable_directories,
         network_domain_permissions: thread.network_domain_permissions,
+        unsandboxed_shell: permissions
+            .shell
+            .as_ref()
+            .is_some_and(|shell| shell.unsandboxed),
     })
 }
 
@@ -1246,6 +1256,7 @@ fn run_command_exec<W: Write>(
         thread_permission_profile,
         runtime_workspace_roots,
         thread_network_domain_permissions,
+        thread_unsandboxed_shell,
     ) = match thread_id {
         Some(thread_id) => {
             state.prune_finished_turns();
@@ -1260,6 +1271,7 @@ fn run_command_exec<W: Write>(
                     thread.active_permission_profile().cloned(),
                     thread.runtime_workspace_roots().to_vec(),
                     thread.network_domain_permissions().clone(),
+                    thread.unsandboxed_shell(),
                 ),
                 None => {
                     return protocol::write_server_event(
@@ -1280,6 +1292,7 @@ fn run_command_exec<W: Write>(
                 .clone()
                 .unwrap_or_default(),
             HashMap::new(),
+            false,
         ),
     };
     let mut effective_sandbox = match command_exec_sandbox_mode(
@@ -1295,6 +1308,10 @@ fn run_command_exec<W: Write>(
             return protocol::write_server_event(writer, &id, ServerEvent::error(error));
         }
     };
+    if thread_unsandboxed_shell {
+        effective_sandbox.mode = ShellSandboxMode::DangerFullAccess;
+        effective_sandbox.denied_writable_roots.clear();
+    }
     for (domain, access) in thread_network_domain_permissions {
         match access {
             orca_core::config::PermissionProfileNetworkAccess::Deny => {
@@ -3976,7 +3993,7 @@ enabled = true
             );
 
             let response = format!(
-                r#"{{"id":"perm-allow","method":"permission/respond","params":{{"requestId":"{request_id}","decision":"allow","scope":"turn","permissions":{{"shell":{{"unsandboxed":true}}}}}}}}"#
+                r#"{{"id":"perm-allow","method":"permission/respond","params":{{"requestId":"{request_id}","decision":"allow","scope":"session","permissions":{{"shell":{{"unsandboxed":true}}}}}}}}"#
             );
             handle_line(&server_config, &mut state, &response, Arc::clone(&writer))
                 .expect("permission response");
@@ -3993,6 +4010,42 @@ enabled = true
                 .expect("command completed");
             assert_eq!(completed["exitCode"], 0);
             assert!(marker.exists());
+
+            let second_marker = outside.join("credential-helper-output-second");
+            let second_request = test_command_exec_request(
+                "cmd-unsandboxed-second",
+                &format!("touch {}", second_marker.display()),
+                json!({"threadId": thread_id, "timeoutMs": 5000}),
+            );
+            handle_line(
+                &server_config,
+                &mut state,
+                &second_request,
+                Arc::clone(&writer),
+            )
+            .expect("second command exec");
+            drain_command_exec_processes_with_timeout(
+                &mut state,
+                &mut *writer.lock().expect("writer"),
+                Duration::from_secs(2),
+            )
+            .expect("drain second retried process");
+            let events = parse_jsonl(&writer.lock().expect("writer").clone());
+            assert!(
+                events.iter().any(|event| {
+                    event["event"] == "command_exec_completed"
+                        && event["id"] == "cmd-unsandboxed-second"
+                        && event["exitCode"] == 0
+                }),
+                "session shell grant should suppress a second approval: {events:?}"
+            );
+            assert!(
+                events.iter().all(|event| {
+                    !(event["event"] == "permission_request"
+                        && event["requestId"] == "permission-command-cmd-unsandboxed-second")
+                }),
+                "second command unexpectedly requested approval: {events:?}"
+            );
         });
     }
 

--- a/crates/orca-runtime/src/server/processors/permission.rs
+++ b/crates/orca-runtime/src/server/processors/permission.rs
@@ -105,6 +105,7 @@ fn run_permission_respond<W: Write>(
                 additional_working_directories: Some(session_grants.additional_working_directories),
                 metadata_writable_directories: Some(session_grants.metadata_writable_directories),
                 network_domain_permissions: Some(session_grants.network_domain_permissions),
+                unsandboxed_shell: Some(session_grants.unsandboxed_shell),
             },
         );
     }

--- a/crates/orca-runtime/src/server/surface_adapter.rs
+++ b/crates/orca-runtime/src/server/surface_adapter.rs
@@ -985,6 +985,16 @@ impl JsonlSurfaceAdapter {
                 permissions: network,
             });
         }
+        let unsandboxed_shell = settings.effective.unsandboxed_shell
+            || permissions
+                .shell
+                .as_ref()
+                .is_some_and(|shell| shell.unsandboxed);
+        if unsandboxed_shell != settings.effective.unsandboxed_shell {
+            patches.push(RuntimeSettingsPatch::SetUnsandboxedShell {
+                enabled: unsandboxed_shell,
+            });
+        }
         let update_result = if let Ok(patches) = NonEmptyVec::try_new(patches) {
             committed(
                 client.update_settings(SurfaceRequestId::new(), settings.thread_revision, patches),
@@ -1007,6 +1017,7 @@ impl JsonlSurfaceAdapter {
                         ),
                         metadata_writable_directories: Some(metadata_writable_directories),
                         network_domain_permissions: Some(persisted_network_domain_permissions),
+                        unsandboxed_shell: Some(unsandboxed_shell),
                         ..ThreadMetadataPatch::default()
                     },
                 )
@@ -1173,6 +1184,7 @@ impl JsonlSurfaceAdapter {
                 additional_working_directories: projection.additional_working_directories,
                 metadata_writable_directories: Vec::new(),
                 network_domain_permissions: projection.network_domain_permissions,
+                unsandboxed_shell: projection.unsandboxed_shell,
                 mcp_registry: thread.mcp_registry(),
             });
         }
@@ -1184,6 +1196,7 @@ impl JsonlSurfaceAdapter {
             additional_working_directories: thread.additional_working_directories,
             metadata_writable_directories: thread.metadata_writable_directories,
             network_domain_permissions: thread.network_domain_permissions,
+            unsandboxed_shell: thread.unsandboxed_shell,
             mcp_registry: self.mcp_registry(thread_id)?,
         })
     }

--- a/crates/orca-runtime/src/session.rs
+++ b/crates/orca-runtime/src/session.rs
@@ -55,6 +55,7 @@ pub struct InteractiveSession {
     auto_memory_turn_starts: HashMap<String, usize>,
     task_registry: TaskRegistry,
     last_manual_compaction: Option<ManualCompactionOutcome>,
+    unsandboxed_shell: bool,
 }
 
 pub(crate) struct InteractiveSessionRuntimeParts<'a> {
@@ -66,6 +67,7 @@ pub(crate) struct InteractiveSessionRuntimeParts<'a> {
     pub hooks: &'a HookRunner,
     pub memory: &'a MemoryBlock,
     pub task_registry: &'a TaskRegistry,
+    pub unsandboxed_shell: bool,
 }
 
 #[derive(Clone, Debug)]
@@ -306,6 +308,12 @@ impl InteractiveSession {
             0
         };
 
+        let unsandboxed_shell = loaded_transcript
+            .as_ref()
+            .is_some_and(|transcript| transcript.meta.unsandboxed_shell)
+            || prepared_record_meta
+                .as_ref()
+                .is_some_and(|meta| meta.unsandboxed_shell);
         let mut session_id = None;
         let writer = match &config.history_mode {
             HistoryMode::Disabled => None,
@@ -422,6 +430,7 @@ impl InteractiveSession {
             auto_memory_turn_starts: HashMap::new(),
             task_registry,
             last_manual_compaction: None,
+            unsandboxed_shell,
         };
         if let (Some(worker), Some(work)) = (
             session.auto_memory_worker.as_ref(),
@@ -466,6 +475,10 @@ impl InteractiveSession {
 
     pub fn session_id(&self) -> Option<&str> {
         self.session_id.as_deref()
+    }
+
+    pub(crate) fn unsandboxed_shell(&self) -> bool {
+        self.unsandboxed_shell
     }
 
     pub(crate) fn event_publication_store(&self) -> Option<(u64, SessionWriter)> {
@@ -639,6 +652,7 @@ impl InteractiveSession {
             hooks: &self.hooks,
             memory: &self.memory,
             task_registry: &self.task_registry,
+            unsandboxed_shell: self.unsandboxed_shell,
         }
     }
 
@@ -714,6 +728,10 @@ impl InteractiveSession {
 
     pub fn set_model(&mut self, model: Option<&str>) {
         self.cost_tracker.set_model(model);
+    }
+
+    pub(crate) fn set_unsandboxed_shell(&mut self, enabled: bool) {
+        self.unsandboxed_shell |= enabled;
     }
 
     pub fn add_pinned_context(&mut self, content: String) {

--- a/crates/orca-runtime/src/thread_store/local.rs
+++ b/crates/orca-runtime/src/thread_store/local.rs
@@ -1019,6 +1019,10 @@ impl ThreadStore for JsonlThreadStore {
                     meta.network_domain_permissions = network_domain_permissions;
                     patched = true;
                 }
+                if let Some(unsandboxed_shell) = patch.unsandboxed_shell {
+                    meta.unsandboxed_shell = unsandboxed_shell;
+                    patched = true;
+                }
                 break;
             }
         }
@@ -1070,6 +1074,7 @@ impl ThreadStore for JsonlThreadStore {
             additional_working_directories: meta.additional_working_directories,
             metadata_writable_directories: meta.metadata_writable_directories,
             network_domain_permissions: meta.network_domain_permissions,
+            unsandboxed_shell: meta.unsandboxed_shell,
             message_count: stored_messages.len(),
             messages: projected_messages,
             turns,

--- a/crates/orca-runtime/src/thread_store/types.rs
+++ b/crates/orca-runtime/src/thread_store/types.rs
@@ -50,6 +50,8 @@ pub struct SessionMeta {
     pub metadata_writable_directories: Vec<PathBuf>,
     #[serde(default, skip_serializing_if = "HashMap::is_empty")]
     pub network_domain_permissions: HashMap<String, PermissionProfileNetworkAccess>,
+    #[serde(default)]
+    pub unsandboxed_shell: bool,
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -585,6 +587,7 @@ pub struct ThreadMetadataPatch {
     pub additional_working_directories: Option<Vec<AdditionalWorkingDirectory>>,
     pub metadata_writable_directories: Option<Vec<PathBuf>>,
     pub network_domain_permissions: Option<HashMap<String, PermissionProfileNetworkAccess>>,
+    pub unsandboxed_shell: Option<bool>,
 }
 
 #[derive(Clone, Debug, PartialEq)]
@@ -597,6 +600,7 @@ pub struct StoredThreadProjection {
     pub additional_working_directories: Vec<AdditionalWorkingDirectory>,
     pub metadata_writable_directories: Vec<PathBuf>,
     pub network_domain_permissions: HashMap<String, PermissionProfileNetworkAccess>,
+    pub unsandboxed_shell: bool,
     pub message_count: usize,
     pub messages: Vec<Value>,
     pub turns: Vec<StoredThreadTurn>,

--- a/crates/orca-runtime/src/thread_store/writer.rs
+++ b/crates/orca-runtime/src/thread_store/writer.rs
@@ -1532,6 +1532,7 @@ mod tests {
             additional_working_directories: Vec::new(),
             metadata_writable_directories: Vec::new(),
             network_domain_permissions: Default::default(),
+            unsandboxed_shell: false,
         };
         write_record(&path, &SessionRecord::Meta(meta)).expect("write metadata");
         let writer = SessionWriter {

--- a/crates/orca-runtime/tests/runtime_surface_attach.rs
+++ b/crates/orca-runtime/tests/runtime_surface_attach.rs
@@ -42,6 +42,7 @@ fn snapshot(next_seq: u64) -> SurfaceSnapshot {
             enabled: Some(true),
             domains: Vec::new(),
         },
+        unsandboxed_shell: false,
         policy_epoch: PolicyEpoch::try_new(1).unwrap(),
     };
     SurfaceSnapshot {

--- a/crates/orca-runtime/tests/runtime_surface_commit.rs
+++ b/crates/orca-runtime/tests/runtime_surface_commit.rs
@@ -72,6 +72,7 @@ fn snapshot() -> SurfaceSnapshot {
             enabled: Some(true),
             domains: Vec::new(),
         },
+        unsandboxed_shell: false,
         policy_epoch: PolicyEpoch::try_new(1).unwrap(),
     };
     SurfaceSnapshot {

--- a/crates/orca-runtime/tests/runtime_surface_reducer.rs
+++ b/crates/orca-runtime/tests/runtime_surface_reducer.rs
@@ -61,6 +61,7 @@ fn settings() -> SurfaceSettingsSnapshot {
                 enabled: Some(true),
                 domains: Vec::new(),
             },
+            unsandboxed_shell: false,
             policy_epoch: PolicyEpoch::try_new(1).unwrap(),
         },
         pending: None,

--- a/crates/orca-tui/src/app.rs
+++ b/crates/orca-tui/src/app.rs
@@ -2763,6 +2763,7 @@ done
                 additional_working_directories: Vec::new(),
                 metadata_writable_directories: Vec::new(),
                 network_domain_permissions: Default::default(),
+                unsandboxed_shell: false,
             },
             messages: Vec::new(),
             compactions: Vec::new(),

--- a/crates/orca-tui/src/hosted_submission.rs
+++ b/crates/orca-tui/src/hosted_submission.rs
@@ -180,6 +180,7 @@ mod tests {
                 additional_working_directories: Vec::new(),
                 metadata_writable_directories: Vec::new(),
                 network_domain_permissions: Default::default(),
+                unsandboxed_shell: false,
             },
             messages: Vec::new(),
             compactions: Vec::new(),

--- a/crates/orca-tui/src/surface_projection.rs
+++ b/crates/orca-tui/src/surface_projection.rs
@@ -2131,6 +2131,7 @@ mod tests {
                         enabled: Some(true),
                         domains: Vec::new(),
                     },
+                    unsandboxed_shell: false,
                     policy_epoch: PolicyEpoch::try_new(1).unwrap(),
                 },
                 pending: None,

--- a/docs/production-roadmap.md
+++ b/docs/production-roadmap.md
@@ -117,9 +117,15 @@ two real requests with `second cache_tokens=1024` (the first also reported
 `cache_tokens=1024` because the remote prefix was already warm), confirming a
 non-zero DeepSeek cache hit without exposing credentials.
 
-Current baseline: v0.3.25 adds checkpointable child-agent continuation,
+Current baseline: v0.3.26 makes the unsandboxed shell permission an
+explicit, reusable, session-scoped capability: the turn permission overlay
+carries it with merge, delta, and apply semantics, bash consumes it before
+prompting, grants are recorded only on allow, and session-scope allow
+responses persist it into thread settings and JSONL metadata so recorded
+sessions restore it into every new turn without re-asking. It builds on
+v0.3.25's checkpointable child-agent continuation,
 runtime-owned durable prompt queues, and Codex-style Goal paste
-materialization. It builds on v0.3.24's durable four-interaction broker and
+materialization. v0.3.25 builds on v0.3.24's durable four-interaction broker and
 v0.3.23's thread-owned interactive `exec_command` and
 `write_stdin` sessions with optional PTY, raw control input, bounded output,
 task-based process-tree control, and a single-owner background supervisor that

--- a/docs/releases/v0.3.26.md
+++ b/docs/releases/v0.3.26.md
@@ -1,0 +1,53 @@
+# Orca v0.3.26
+
+Patch release: make the unsandboxed shell permission an explicit, reusable, session-scoped capability so a sandbox denial cannot trigger repeated approval requests within a session.
+
+## Reusable unsandboxed shell capability
+
+- Add `unsandboxed_shell` as a first-class field of the turn permission overlay and its delta, with merge, delta, and apply semantics that preserve the capability across permission updates.
+- Bash consumes the capability before prompting: when the current overlay already grants it, commands run directly with the full-access sandbox instead of re-requesting permission.
+- A grant is recorded in the overlay only after an allow response; unrelated permission deltas can never introduce the capability.
+- Pathless sandbox denials keep their explicit unsandboxed-shell retry fingerprint from the centralized permission request policy; once granted, repeated denials in the same turn no longer prompt again.
+
+## Session-scoped grants
+
+- Allow responses with session scope materialize the shell capability into thread settings (`SetUnsandboxedShell` settings patch, enable-only) and persist it in the JSONL session metadata.
+- The capability is restored into every new turn of a recorded session and into `command_exec` server operations, which adopt the full-access sandbox when the thread holds it.
+- Recorded sessions survive restart; ephemeral (unrecorded) sessions keep the capability runtime-only.
+- Session grant deltas are validated against the requested permission profile, and the capability cannot be silently revoked once granted.
+
+## Compatibility
+
+- CLI commands, JSONL session metadata, npm package names, and release archive layouts remain compatible.
+- The JSONL session metadata gains an optional `unsandboxed_shell` field with a serde default, so transcripts written by older versions load unchanged.
+- The runtime surface contract adds the `unsandboxed_shell` setting field and `SetUnsandboxedShell` patch; the permission retry capsule carries the capability with a serde default for older clients.
+
+## Verification
+
+```bash
+cargo fmt --all -- --check
+cargo check --workspace --tests --jobs 5
+cargo build --workspace --jobs 5
+cargo clippy --workspace --all-targets --locked
+cargo test -p orca-tui --lib -- --test-threads=5
+node scripts/test-validate-runtime-surface-contract.mjs
+node scripts/validate-runtime-surface-contract.mjs
+node scripts/test-validate-windows-platform-boundaries.mjs
+node scripts/validate-windows-platform-boundaries.mjs
+node scripts/release/test-verify-version-sync.mjs
+node scripts/release/test-stage-npm.mjs
+node scripts/release/test-verify-published.mjs
+npm --prefix site run build
+npm --prefix site run check:seo
+git diff --check
+```
+
+The tag-triggered release workflow additionally runs the complete nextest workspace, PTY, Linux, macOS, native Windows x64 and Windows ARM64 gates before publishing the GitHub Release and npm packages.
+
+## Install
+
+```bash
+npm install -g @blade-ai/orca@0.3.26
+```
+
+Or download the platform archive from the GitHub Release and verify the included SHA-256 checksum.

--- a/docs/superpowers/plans/2026-08-21-approval-capabilities.md
+++ b/docs/superpowers/plans/2026-08-21-approval-capabilities.md
@@ -1,0 +1,66 @@
+# Approval Capabilities Refactor Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make permission grants explicit, scoped, reusable, and durable so a sandbox denial cannot trigger repeated approval requests or silently widen authority.
+
+**Architecture:** Runtime permission responses are normalized into a capability set with `Turn` or `Session` scope. The turn overlay carries only active capabilities; session capabilities are materialized into thread settings and restored into every new turn. Shell unsandboxed authority is a first-class capability, not an implicit retry mode. All retries are bound to the exact requested capability and denied when the diagnostic is not safely attributable.
+
+**Tech Stack:** Rust workspace, `orca-runtime` runtime/surface layers, JSONL session metadata, existing Seatbelt/Linux sandbox adapters, unit and integration tests.
+
+---
+
+### Task 1: Add first-class shell capability to runtime permission state
+
+**Files:**
+- Modify: `crates/orca-runtime/src/runtime_permission.rs`
+- Test: `crates/orca-runtime/src/runtime_permission.rs`
+
+- [ ] Add `unsandboxed_shell: bool` to the turn overlay and its delta.
+- [ ] Make permission merging, delta calculation, and delta application preserve the capability.
+- [ ] Add tests proving the capability is reusable in a turn and cannot be introduced by an unrelated delta.
+
+### Task 2: Make bash consume capabilities before prompting
+
+**Files:**
+- Modify: `crates/orca-runtime/src/runtime_bash.rs`
+- Modify: `crates/orca-runtime/src/runtime_permission.rs`
+- Test: `crates/orca-runtime/src/runtime_bash.rs`
+
+- [ ] Skip the unsandboxed permission request when the current overlay already grants it.
+- [ ] Record the grant in the overlay only after an allow response.
+- [ ] Add a regression test for two pathless denials in one turn requiring one request.
+
+### Task 3: Persist session shell capability through surface and JSONL metadata
+
+**Files:**
+- Modify: `crates/orca-runtime/src/runtime_surface/operation.rs`
+- Modify: `crates/orca-runtime/src/runtime_surface/interaction.rs`
+- Modify: `crates/orca-runtime/src/runtime_host.rs`
+- Modify: `crates/orca-runtime/src/server/processors/permission.rs`
+- Modify: `crates/orca-runtime/src/server/surface_adapter.rs`
+- Modify: `crates/orca-runtime/src/thread_store/types.rs`
+- Modify: `crates/orca-runtime/src/thread_store/local.rs`
+- Test: affected surface and server tests
+
+- [ ] Add session settings and retry capsule fields for shell capability.
+- [ ] Validate session grants as a subset of the requested profile.
+- [ ] Persist and restore shell capability for recorded sessions; keep ephemeral sessions runtime-only.
+
+### Task 4: Enforce denial attribution and event semantics
+
+**Files:**
+- Modify: `crates/orca-runtime/src/sandbox_denial.rs`
+- Modify: `crates/orca-runtime/src/runtime_bash.rs`
+- Modify: `crates/orca-runtime/src/tool_execution.rs`
+- Test: denial and approval event tests
+
+- [ ] Classify pathless denials with an explicit retry fingerprint.
+- [ ] Bound repeated identical retries within a turn and fail closed after the bound.
+- [ ] Keep automatic authorization in the audit stream but stop projecting it as a user approval interaction.
+
+### Task 5: Verification
+
+- [ ] Run focused `orca-runtime` tests for permission, bash, server, and surface modules.
+- [ ] Run `cargo fmt --check` and `git diff --check`.
+- [ ] Run the affected package test gate and record any environment-gated sandbox tests that cannot run.

--- a/docs/superpowers/plans/2026-08-21-approval-capabilities.md
+++ b/docs/superpowers/plans/2026-08-21-approval-capabilities.md
@@ -2,6 +2,8 @@
 
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
 
+**Status:** Tasks 1–3 implemented in `refactor: persist reusable shell permission capabilities` (5640858b0) and verified by the workspace gate. Task 4 item 1 was already satisfied by the centralized permission request policy (`refactor(runtime): centralize permission request policy`, 6d1e6d48d); Task 4 items 2–3 remain future hardening and are intentionally left unchecked.
+
 **Goal:** Make permission grants explicit, scoped, reusable, and durable so a sandbox denial cannot trigger repeated approval requests or silently widen authority.
 
 **Architecture:** Runtime permission responses are normalized into a capability set with `Turn` or `Session` scope. The turn overlay carries only active capabilities; session capabilities are materialized into thread settings and restored into every new turn. Shell unsandboxed authority is a first-class capability, not an implicit retry mode. All retries are bound to the exact requested capability and denied when the diagnostic is not safely attributable.
@@ -16,9 +18,9 @@
 - Modify: `crates/orca-runtime/src/runtime_permission.rs`
 - Test: `crates/orca-runtime/src/runtime_permission.rs`
 
-- [ ] Add `unsandboxed_shell: bool` to the turn overlay and its delta.
-- [ ] Make permission merging, delta calculation, and delta application preserve the capability.
-- [ ] Add tests proving the capability is reusable in a turn and cannot be introduced by an unrelated delta.
+- [x] Add `unsandboxed_shell: bool` to the turn overlay and its delta.
+- [x] Make permission merging, delta calculation, and delta application preserve the capability.
+- [x] Add tests proving the capability is reusable in a turn and cannot be introduced by an unrelated delta.
 
 ### Task 2: Make bash consume capabilities before prompting
 
@@ -27,9 +29,9 @@
 - Modify: `crates/orca-runtime/src/runtime_permission.rs`
 - Test: `crates/orca-runtime/src/runtime_bash.rs`
 
-- [ ] Skip the unsandboxed permission request when the current overlay already grants it.
-- [ ] Record the grant in the overlay only after an allow response.
-- [ ] Add a regression test for two pathless denials in one turn requiring one request.
+- [x] Skip the unsandboxed permission request when the current overlay already grants it.
+- [x] Record the grant in the overlay only after an allow response.
+- [x] Add a regression test for two pathless denials in one turn requiring one request.
 
 ### Task 3: Persist session shell capability through surface and JSONL metadata
 
@@ -43,9 +45,9 @@
 - Modify: `crates/orca-runtime/src/thread_store/local.rs`
 - Test: affected surface and server tests
 
-- [ ] Add session settings and retry capsule fields for shell capability.
-- [ ] Validate session grants as a subset of the requested profile.
-- [ ] Persist and restore shell capability for recorded sessions; keep ephemeral sessions runtime-only.
+- [x] Add session settings and retry capsule fields for shell capability.
+- [x] Validate session grants as a subset of the requested profile.
+- [x] Persist and restore shell capability for recorded sessions; keep ephemeral sessions runtime-only.
 
 ### Task 4: Enforce denial attribution and event semantics
 
@@ -55,7 +57,7 @@
 - Modify: `crates/orca-runtime/src/tool_execution.rs`
 - Test: denial and approval event tests
 
-- [ ] Classify pathless denials with an explicit retry fingerprint.
+- [x] Classify pathless denials with an explicit retry fingerprint.
 - [ ] Bound repeated identical retries within a turn and fail closed after the bound.
 - [ ] Keep automatic authorization in the audit stream but stop projecting it as a user approval interaction.
 

--- a/npm/orca/package.json
+++ b/npm/orca/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@blade-ai/orca",
-  "version": "0.3.25",
+  "version": "0.3.26",
   "description": "Orca CLI: a DeepSeek-native coding agent.",
   "homepage": "https://orcaagent.dev/",
   "license": "MIT",

--- a/site/public/sitemap.xml
+++ b/site/public/sitemap.xml
@@ -2,37 +2,37 @@
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
     <loc>https://orcaagent.dev/</loc>
-    <lastmod>2026-08-20</lastmod>
+    <lastmod>2026-08-21</lastmod>
     <changefreq>weekly</changefreq>
     <priority>1.0</priority>
   </url>
   <url>
     <loc>https://orcaagent.dev/changelog/</loc>
-    <lastmod>2026-08-20</lastmod>
+    <lastmod>2026-08-21</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://orcaagent.dev/terminal-coding-agent/</loc>
-    <lastmod>2026-08-20</lastmod>
+    <lastmod>2026-08-21</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://orcaagent.dev/deepseek-coding-agent/</loc>
-    <lastmod>2026-08-20</lastmod>
+    <lastmod>2026-08-21</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://orcaagent.dev/github/</loc>
-    <lastmod>2026-08-20</lastmod>
+    <lastmod>2026-08-21</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.75</priority>
   </url>
   <url>
     <loc>https://orcaagent.dev/mcp/</loc>
-    <lastmod>2026-08-20</lastmod>
+    <lastmod>2026-08-21</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.75</priority>
   </url>

--- a/site/src/changelog/Changelog.tsx
+++ b/site/src/changelog/Changelog.tsx
@@ -78,6 +78,8 @@ const copy = {
       ],
     },
     summaries: {
+      "v0.3.26":
+        "Makes the unsandboxed shell permission an explicit, reusable, session-scoped capability. The turn permission overlay and its delta now carry the capability with merge and apply semantics that preserve it, bash consumes it before prompting so a granted session never re-asks, and grants are recorded only after an allow response. Session-scope allow responses persist the capability into thread settings and JSONL metadata, restore it into every new turn and command_exec operation, validate grant deltas against the requested profile, and cannot be silently revoked.",
       "v0.3.25":
         "Adds runtime-owned, checkpointable continuation lineages for synchronous subagents, async workers, and Workflow children. Leased attempts, revision fencing, digest-verified conversation checkpoints, compatibility identities, pre-dispatch replay boundaries, and cold orphan reconciliation resume only safe durable facts and fail closed on indeterminate side effects; retryable resumable Workflow attempts retain their worktree. The durable prompt queue projects one admission and lifecycle model across TUI, ACP, JSONL, and Headless, routes Alt+Up editing through a revision-checked delete, restores rejected prompts, and bounds previews. The TUI keeps large ordinary-chat pastes as compact chips while sending the complete text, enforces the 1 MiB limit, and materializes active Goal pastes and oversized objectives into validated ORCA_HOME attachment files with cleanup on uncommitted failure.",
       "v0.3.24":
@@ -612,6 +614,8 @@ const copy = {
       ],
     },
     summaries: {
+      "v0.3.26":
+        "把 unsandboxed shell 权限变成显式、可复用、会话级的能力。turn 权限 overlay 与其 delta 现在携带该能力，合并与应用语义保证它不会被无关权限更新抹掉；bash 在请求前先消费该能力，会话一旦授权就不再重复弹窗，且授权只在 allow 响应后记录。会话级 allow 会把能力持久化到 thread settings 与 JSONL 元数据，并在每个新 turn 和 command_exec 操作中恢复；授权 delta 会按请求 profile 校验，且一旦授予就不能被静默撤销。",
       "v0.3.25":
         "为同步子代理、异步 worker 和 Workflow 子代理新增 runtime-owned、可检查点恢复的 continuation lineage。带 lease 的 attempt、revision fencing、摘要校验的会话 checkpoint、兼容性身份、工具分发前 replay boundary 与冷启动 orphan reconciliation 只恢复安全的持久化事实，对副作用不明的状态保持 fail closed；可重试且可恢复的 Workflow attempt 会保留 worktree。Durable prompt queue 在 TUI、ACP、JSONL 和 Headless 上投影同一套准入与生命周期，Alt+Up 编辑通过 revision-checked delete 提交，失败准入恢复完整 prompt，预览保持有界。TUI 以紧凑 chip 保存普通聊天大文本并在提交时恢复全文，执行 1 MiB 上限；Goal 中仍有效的 paste 和超长 objective 会写入经过路径校验的 ORCA_HOME 附件，未提交失败会自动清理。",
       "v0.3.24":

--- a/site/src/shared.ts
+++ b/site/src/shared.ts
@@ -4,9 +4,16 @@ export const localeStorageKey = "orca-site-locale";
 export const canonicalOrigin = "https://orcaagent.dev";
 export const socialImageUrl = `${canonicalOrigin}/orca-social.png`;
 
-export const releaseVersion = "v0.3.25";
+export const releaseVersion = "v0.3.26";
 
 export const releases = [
+  {
+    version: "v0.3.26",
+    date: "2026-08-21",
+    title: "Reusable session-scoped shell permission capability",
+    body: "Makes the unsandboxed shell permission an explicit, reusable capability: it lives in the turn permission overlay with delta and merge semantics, bash consumes it before prompting, and a grant is recorded only on allow. Session-scoped allow responses persist the capability into thread settings and JSONL metadata, restore it into every new turn and command_exec operation, and validate grant deltas against the requested profile, so a sandbox denial can never trigger repeated approval requests or silently widen authority.",
+    url: "https://github.com/echoVic/orca-agent/releases/tag/v0.3.26",
+  },
   {
     version: "v0.3.25",
     date: "2026-08-20",


### PR DESCRIPTION
## Summary

Refactor: make the unsandboxed shell permission an explicit, reusable, session-scoped capability (`refactor/approval-capabilities`):

- `unsandboxed_shell` becomes a first-class field of the turn permission overlay and its delta, preserved across merge/delta/apply.
- Bash consumes the capability before prompting; grants are recorded only on allow, so a granted session never re-asks.
- Session-scope allow responses persist the capability into thread settings (`SetUnsandboxedShell`, enable-only) and JSONL session metadata; recorded sessions restore it into every new turn and `command_exec` operations.
- Session grant deltas are validated against the requested permission profile.

Follow-ups in this PR:

- `fix(tui)`: complete shell capability test fixture fields (missing `unsandboxed_shell` initializers in three test fixtures).
- Docs: plan completion recorded, production roadmap baseline bumped.
- `release: prepare v0.3.26` (Cargo.toml / Cargo.lock / npm `@blade-ai/orca`).
- Site: v0.3.26 changelog entry (EN + ZH), release list, sitemap lastmod.

## Verification

- `cargo fmt --all -- --check` — clean
- `cargo clippy --workspace --all-targets --locked` — clean, no new warnings
- `cargo nextest` — orca-runtime lib 1214/1214, orca-tui lib 1171/1171, tui_pty_contract 6/6; full workspace gate running locally in parallel with CI
- Contract validators, Windows boundary validators, version-sync, stage-npm, verify-published, repository hygiene, terminal_bench Python suite — all pass
- Site build + SEO check — pass

Release notes: `docs/releases/v0.3.26.md`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added reusable, session-scoped unsandboxed shell access.
  - Shell commands can run with full access after authorization without repeated prompts.
  - Permissions persist across sessions and restore automatically for new turns.
  - Added controls to enable the capability; once enabled, it cannot be disabled for that session.

- **Documentation**
  - Added v0.3.26 release notes and updated roadmap and website changelogs.

- **Release**
  - Updated the application and package versions to v0.3.26.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->