### PR TITLE
release: prepare v0.4.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -235,7 +235,7 @@ checksum = "84d7ced0ae9557296835c32bf1b1e02b44c746701f898460fb000d7eaa84f00a"
 
 [[package]]
 name = "blade-deepseek"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "base64",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,7 +53,7 @@ arboard = { version = "3", features = ["wayland-data-control"] }
 
 [package]
 name = "blade-deepseek"
-version = "0.4.0"
+version = "0.4.1"
 edition = "2024"
 description = "Orca: a DeepSeek-native coding agent"
 license = "MIT"

--- a/docs/production-roadmap.md
+++ b/docs/production-roadmap.md
@@ -131,7 +131,12 @@ two real requests with `second cache_tokens=1024` (the first also reported
 `cache_tokens=1024` because the remote prefix was already warm), confirming a
 non-zero DeepSeek cache hit without exposing credentials.
 
-Current baseline: v0.4.0 adds DeepSeek vision and the complete TUI/ACP image
+Current baseline: v0.4.1 batches provider step commits with deferred
+surface refresh, caches token counts, shards the reducer state, and
+coalesces consecutive delta events before renderer dispatch; it also
+hardens sandbox metadata handling so symlinked or forged metadata roots
+cannot widen grants, and classifies workflow active state by exclusion.
+v0.4.0 adds DeepSeek vision and the complete TUI/ACP image
 input path, completes the focused `ThreadActor` controller split, and adds
 stable context-window epochs. v0.3.26 makes the unsandboxed shell permission an
 explicit, reusable, session-scoped capability: the turn permission overlay

--- a/docs/releases/v0.4.1.md
+++ b/docs/releases/v0.4.1.md
@@ -1,0 +1,61 @@
+# Orca v0.4.1
+
+Patch release: speed up streaming runtime surfaces, harden sandbox metadata
+permission handling, and stabilize the workflow active-state contract.
+
+## Streaming and provider performance
+
+- Batch provider step commits through `RuntimeProviderResponseIngress` and defer surface refreshes, reducing per-delta overhead for streamed responses.
+- Cache token counts to avoid repeated computation across steps.
+- Split `SurfaceReducerState` storage across sharded `BTreeMap`s to reduce contention on large transcripts.
+- Coalesce consecutive `MessageDelta` and `ReasoningDelta` runtime events into bounded merged deltas before renderer dispatch, cutting UI render passes.
+- Rebuild the `SurfaceCommitLedger` index for faster probe of prepared and committed batches; simplify provider conversation message normalization and remove the redundant `probe_surface_commit` path.
+
+## Sandbox metadata permission hardening
+
+- Linux/bubblewrap discovers existing nested protected metadata (`.git`, `.agents`, `.codex`) under writable roots before launch and re-binds it read-only, so an ordinary writable-root grant cannot mint metadata write authority.
+- Symlinked metadata roots can no longer widen an explicit grant; granted protected roots are only recorded when they pass the `is_safe_metadata_writable_root` guard (a symlinked metadata directory is rejected, while not-yet-created protected paths remain admissible because the sandbox re-checks at launch).
+- Session-grant materialization, `command_exec` sandbox resolution, and the turn permission overlay apply the same guard, keeping dedicated metadata authority provenance-separate from ordinary working directories.
+- Reserved `session-metadata` directory sources are ignored at the runtime thread boundary and by ordinary permission updates, so forged configuration cannot mint metadata escalation authority.
+- Bash and the tool router keep protected metadata paths out of ordinary additional working directories.
+
+## Workflow and test stabilization
+
+- `wait_until_active` now classifies active state by exclusion (any non-terminal status) instead of a `queued`/`running` allowlist, and reports the observed status sequence on failure so a future gap names itself instead of looking like a timing flake.
+- TUI permission round-trip tests await the completed mock turn; subagent launch failures surface captured stdout/stderr; the mock provider reuses fresh tool ids across turns and stops after a result.
+- CI baseline refresh: the runtime surface contract anchors and self-test fixtures track the coalesced renderer runtime inbox shape; the Windows platform boundary manifest registers the new unix-only symlink fixtures.
+
+## Compatibility
+
+- CLI commands, JSONL session metadata, runtime surface wire formats, npm package names, and release archive layouts remain compatible.
+- No persisted session, goal, or workflow formats change.
+
+## Verification
+
+```bash
+cargo fmt --all -- --check
+cargo check --workspace --tests --jobs 5
+cargo build --workspace --jobs 5
+cargo clippy --workspace --all-targets --locked
+cargo test -p orca-tui --lib -- --test-threads=5
+node scripts/test-validate-runtime-surface-contract.mjs
+node scripts/validate-runtime-surface-contract.mjs
+node scripts/test-validate-windows-platform-boundaries.mjs
+node scripts/validate-windows-platform-boundaries.mjs
+node scripts/release/test-verify-version-sync.mjs
+node scripts/release/test-stage-npm.mjs
+node scripts/release/test-verify-published.mjs
+npm --prefix site run build
+npm --prefix site run check:seo
+git diff --check
+```
+
+The tag-triggered release workflow additionally runs the complete nextest workspace, PTY, Linux, macOS, native Windows x64 and Windows ARM64 gates before publishing the GitHub Release and npm packages.
+
+## Install
+
+```bash
+npm install -g @blade-ai/orca@0.4.1
+```
+
+Or download the platform archive from the GitHub Release and verify the included SHA-256 checksum.

--- a/npm/orca/package.json
+++ b/npm/orca/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@blade-ai/orca",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "Orca CLI: a DeepSeek-native coding agent.",
   "homepage": "https://orcaagent.dev/",
   "license": "MIT",

--- a/site/public/sitemap.xml
+++ b/site/public/sitemap.xml
@@ -2,37 +2,37 @@
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
     <loc>https://orcaagent.dev/</loc>
-    <lastmod>2026-08-22</lastmod>
+    <lastmod>2026-08-23</lastmod>
     <changefreq>weekly</changefreq>
     <priority>1.0</priority>
   </url>
   <url>
     <loc>https://orcaagent.dev/changelog/</loc>
-    <lastmod>2026-08-22</lastmod>
+    <lastmod>2026-08-23</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://orcaagent.dev/terminal-coding-agent/</loc>
-    <lastmod>2026-08-22</lastmod>
+    <lastmod>2026-08-23</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://orcaagent.dev/deepseek-coding-agent/</loc>
-    <lastmod>2026-08-22</lastmod>
+    <lastmod>2026-08-23</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://orcaagent.dev/github/</loc>
-    <lastmod>2026-08-22</lastmod>
+    <lastmod>2026-08-23</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.75</priority>
   </url>
   <url>
     <loc>https://orcaagent.dev/mcp/</loc>
-    <lastmod>2026-08-22</lastmod>
+    <lastmod>2026-08-23</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.75</priority>
   </url>

--- a/site/src/changelog/Changelog.tsx
+++ b/site/src/changelog/Changelog.tsx
@@ -78,6 +78,8 @@ const copy = {
       ],
     },
     summaries: {
+      "v0.4.1":
+        "Speeds up streaming surfaces by batching provider step commits behind deferred refresh, caching token counts, sharding the reducer state across BTreeMaps, and coalescing consecutive MessageDelta and ReasoningDelta events into bounded merged deltas before renderer dispatch. Hardens sandbox metadata permission handling: Linux/bubblewrap discovers nested protected metadata under writable roots and re-binds it read-only, symlinked metadata roots cannot widen an explicit grant, session grants are recorded only after a safety guard, and reserved session-metadata sources are ignored at the thread boundary and by ordinary permission updates. Workflow active-state classification switches from an allowlist to exclusion with reported status sequences.",
       "v0.4.0":
         "Adds complete image input across every model selection: the vision model receives images directly, while auto, Pro, and Flash use a task-aware vision analysis before continuing with the selected coding model. Ctrl+V system-clipboard paste, Windows Alt+V, forwarded Cmd+V, dragged or pasted image paths and file URLs, and @file mentions become atomic [Image #N] attachments with composer previews, message-area thumbnails, and a zoomable viewer. Kitty, Ghostty, iTerm2, and WezTerm render native-pixel previews, while other terminals retain a true-color cell fallback. Background reads, request fencing, paste-before-send ordering, image-only turns, queue editing, rejection recovery, durable history, ACP image blocks, and provider replay preserve the same typed input across macOS, Linux, Windows, and WSL. RuntimeHost also delegates generation context, interaction routing, operation recovery, Goal control, and task/workflow ownership to focused controllers, with stable ContextWindowId compaction epochs.",
       "v0.3.26":
@@ -616,6 +618,8 @@ const copy = {
       ],
     },
     summaries: {
+      "v0.4.1":
+        "通过批量提交 provider 步骤并延迟 surface 刷新、缓存 token 计数、用分片 BTreeMap 重构 reducer 状态、以及在渲染器分发前把连续的 MessageDelta/ReasoningDelta 合并成有界增量，显著提升流式响应性能。同时加固沙箱元数据权限：Linux/bubblewrap 在启动前发现可写根目录下嵌套的受保护元数据并只读重绑定，符号链接元数据根无法扩大授权，会话授权需通过安全检查才会记录，保留的 session-metadata 来源在线程边界和普通权限更新中被忽略，伪造配置无法铸造元数据提权。Workflow 活动状态判定从 allowlist 改为排除法，并在失败时报告观测到的状态序列。",
       "v0.4.0":
         "完整接入 deepseek-v4-flash-vision-exp 图片输入：Ctrl+V 系统剪贴板、Windows Alt+V、终端转发的 Cmd+V、拖入或粘贴图片路径与 file URL、@file mention 都会形成原子的 [Image #N] 附件；Kitty、Ghostty、iTerm2 和 WezTerm 使用原生像素预览，其他终端保留真彩色字符降级。后台读取、request fence、先粘贴后提交顺序、纯图片回合、队列编辑、失败恢复、持久化历史、ACP 图片块与 provider replay 在 macOS、Linux、Windows 和 WSL 上共用同一类型化输入链路。RuntimeHost 同时把 generation context、interaction routing、operation recovery、Goal control 与 task/workflow ownership 下沉到专用 controller，并以稳定 ContextWindowId 标识 compaction epoch。",
       "v0.3.26":

--- a/site/src/shared.ts
+++ b/site/src/shared.ts
@@ -4,9 +4,16 @@ export const localeStorageKey = "orca-site-locale";
 export const canonicalOrigin = "https://orcaagent.dev";
 export const socialImageUrl = `${canonicalOrigin}/orca-social.png`;
 
-export const releaseVersion = "v0.4.0";
+export const releaseVersion = "v0.4.1";
 
 export const releases = [
+  {
+    version: "v0.4.1",
+    date: "2026-08-23",
+    title: "Faster streaming surfaces and hardened sandbox metadata",
+    body: "Batches provider step commits with deferred surface refresh, caches token counts, shards the reducer state, and coalesces consecutive MessageDelta/ReasoningDelta events before renderer dispatch to cut UI render passes. Sandbox metadata handling hardens: Linux/bubblewrap re-binds nested protected metadata read-only, symlinked metadata roots cannot widen grants, session grants pass a safety guard before recording, and reserved session-metadata sources are ignored at the thread boundary so forged configuration cannot mint metadata escalation authority. Workflow active-state classification switches to exclusion with reported status sequences.",
+    url: "https://github.com/echoVic/orca-agent/releases/tag/v0.4.1",
+  },
   {
     version: "v0.4.0",
     date: "2026-08-22",


### PR DESCRIPTION
## Summary

Patch release v0.4.1 on top of v0.4.0 + #14 (sandbox metadata hardening) + #16 (workflow active-state fix) + the runtime/provider streaming optimizations already on main.

- `release: prepare v0.4.1` — Cargo.toml / Cargo.lock / npm `@blade-ai/orca` 0.4.0 → 0.4.1, release notes `docs/releases/v0.4.1.md`, roadmap baseline.
- `chore(site)` — v0.4.1 changelog entry (EN + ZH), release list, sitemap lastmod.

Release notes: `docs/releases/v0.4.1.md`.

## Verification

- `cargo fmt --check`, `cargo clippy --workspace --all-targets` — clean
- `cargo nextest` orca-runtime lib + orca-tools — 1470/1470
- `node scripts/release/verify-version-sync.mjs` — 0.4.1 synced
- Site build + SEO check — pass
- Full workspace gates already green on main (Runtime Surface Contract + Windows for every merged commit)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added batched provider-step commits with deferred surface refresh.
  - Improved streaming performance through token-count caching, reducer-state sharding, and consecutive delta-event coalescing.
  - Added more accurate Workflow active-state classification.

- **Bug Fixes**
  - Hardened sandbox metadata permission and validation handling.

- **Documentation**
  - Published v0.4.1 release notes, roadmap updates, installation guidance, compatibility details, and verification information.
  - Updated English and Chinese changelogs and release metadata.

- **Chores**
  - Updated package and application version information to v0.4.1.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->