### PR TITLE
release: prepare v0.4.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -235,7 +235,7 @@ checksum = "84d7ced0ae9557296835c32bf1b1e02b44c746701f898460fb000d7eaa84f00a"
 
 [[package]]
 name = "blade-deepseek"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "base64",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,7 +53,7 @@ arboard = { version = "3", features = ["wayland-data-control"] }
 
 [package]
 name = "blade-deepseek"
-version = "0.4.1"
+version = "0.4.2"
 edition = "2024"
 description = "Orca: a DeepSeek-native coding agent"
 license = "MIT"

--- a/docs/production-roadmap.md
+++ b/docs/production-roadmap.md
@@ -131,7 +131,10 @@ two real requests with `second cache_tokens=1024` (the first also reported
 `cache_tokens=1024` because the remote prefix was already warm), confirming a
 non-zero DeepSeek cache hit without exposing credentials.
 
-Current baseline: v0.4.1 batches provider step commits with deferred
+Current baseline: v0.4.2 indexes surface commit batches by id so
+recovery of long recorded surface logs scales linearly instead of
+quadratically, with a bounded-time regression gate. v0.4.1 batches
+provider step commits with deferred
 surface refresh, caches token counts, shards the reducer state, and
 coalesces consecutive delta events before renderer dispatch; it also
 hardens sandbox metadata handling so symlinked or forged metadata roots

--- a/docs/releases/v0.4.2.md
+++ b/docs/releases/v0.4.2.md
@@ -1,0 +1,44 @@
+# Orca v0.4.2
+
+Patch release: make surface commit batch recovery linear instead of quadratic for long JSONL logs.
+
+## Surface commit recovery performance
+
+- Index prepared surface commit batches by commit id while scanning the surface JSONL log, replacing the previous linear scan per prepared/committed record.
+- Recovery of a long recorded surface log now scales linearly with the number of commit records instead of quadratically.
+- Add a bounded-time regression test that recovers 25,000 prepared/committed pairs within five seconds.
+
+## Compatibility
+
+- CLI commands, JSONL session metadata, runtime surface wire formats, npm package names, and release archive layouts remain compatible.
+- No persisted session, goal, or workflow formats change; the recovery record layout is identical.
+
+## Verification
+
+```bash
+cargo fmt --all -- --check
+cargo check --workspace --tests --jobs 5
+cargo build --workspace --jobs 5
+cargo clippy --workspace --all-targets --locked
+cargo test -p orca-tui --lib -- --test-threads=5
+node scripts/test-validate-runtime-surface-contract.mjs
+node scripts/validate-runtime-surface-contract.mjs
+node scripts/test-validate-windows-platform-boundaries.mjs
+node scripts/validate-windows-platform-boundaries.mjs
+node scripts/release/test-verify-version-sync.mjs
+node scripts/release/test-stage-npm.mjs
+node scripts/release/test-verify-published.mjs
+npm --prefix site run build
+npm --prefix site run check:seo
+git diff --check
+```
+
+The tag-triggered release workflow additionally runs the complete nextest workspace, PTY, Linux, macOS, native Windows x64 and Windows ARM64 gates before publishing the GitHub Release and npm packages.
+
+## Install
+
+```bash
+npm install -g @blade-ai/orca@0.4.2
+```
+
+Or download the platform archive from the GitHub Release and verify the included SHA-256 checksum.

--- a/npm/orca/package.json
+++ b/npm/orca/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@blade-ai/orca",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "description": "Orca CLI: a DeepSeek-native coding agent.",
   "homepage": "https://orcaagent.dev/",
   "license": "MIT",

--- a/site/src/changelog/Changelog.tsx
+++ b/site/src/changelog/Changelog.tsx
@@ -78,6 +78,8 @@ const copy = {
       ],
     },
     summaries: {
+      "v0.4.2":
+        "Indexes prepared surface commit batches by commit id during surface JSONL log recovery, replacing a linear scan per record so recovery scales linearly instead of quadratically. A bounded-time regression test recovers 25,000 prepared/committed pairs within five seconds.",
       "v0.4.1":
         "Speeds up streaming surfaces by batching provider step commits behind deferred refresh, caching token counts, sharding the reducer state across BTreeMaps, and coalescing consecutive MessageDelta and ReasoningDelta events into bounded merged deltas before renderer dispatch. Hardens sandbox metadata permission handling: Linux/bubblewrap discovers nested protected metadata under writable roots and re-binds it read-only, symlinked metadata roots cannot widen an explicit grant, session grants are recorded only after a safety guard, and reserved session-metadata sources are ignored at the thread boundary and by ordinary permission updates. Workflow active-state classification switches from an allowlist to exclusion with reported status sequences.",
       "v0.4.0":
@@ -618,6 +620,8 @@ const copy = {
       ],
     },
     summaries: {
+      "v0.4.2":
+        "在扫描录制 surface JSONL 日志时按 commit id 建立 prepared batch 索引，替代逐条线性查找，使恢复耗时从平方级降为线性。新增有界时间回归测试：5 秒内恢复 25,000 组 prepared/committed 记录。",
       "v0.4.1":
         "通过批量提交 provider 步骤并延迟 surface 刷新、缓存 token 计数、用分片 BTreeMap 重构 reducer 状态、以及在渲染器分发前把连续的 MessageDelta/ReasoningDelta 合并成有界增量，显著提升流式响应性能。同时加固沙箱元数据权限：Linux/bubblewrap 在启动前发现可写根目录下嵌套的受保护元数据并只读重绑定，符号链接元数据根无法扩大授权，会话授权需通过安全检查才会记录，保留的 session-metadata 来源在线程边界和普通权限更新中被忽略，伪造配置无法铸造元数据提权。Workflow 活动状态判定从 allowlist 改为排除法，并在失败时报告观测到的状态序列。",
       "v0.4.0":

--- a/site/src/shared.ts
+++ b/site/src/shared.ts
@@ -4,9 +4,16 @@ export const localeStorageKey = "orca-site-locale";
 export const canonicalOrigin = "https://orcaagent.dev";
 export const socialImageUrl = `${canonicalOrigin}/orca-social.png`;
 
-export const releaseVersion = "v0.4.1";
+export const releaseVersion = "v0.4.2";
 
 export const releases = [
+  {
+    version: "v0.4.2",
+    date: "2026-08-23",
+    title: "Linear surface commit recovery",
+    body: "Indexes prepared surface commit batches by commit id while scanning the recorded surface JSONL log, so recovery scales linearly with the number of commit records instead of quadratically. A bounded-time regression test recovers 25,000 prepared/committed pairs within five seconds.",
+    url: "https://github.com/echoVic/orca-agent/releases/tag/v0.4.2",
+  },
   {
     version: "v0.4.1",
     date: "2026-08-23",


### PR DESCRIPTION
## Summary

Patch release v0.4.2 on top of the surface commit recovery optimization already on main (`perf(runtime): index surface commit batches by id`).

- `release: prepare v0.4.2` — Cargo.toml / Cargo.lock / npm `@blade-ai/orca` 0.4.1 → 0.4.2, release notes `docs/releases/v0.4.2.md`, roadmap baseline.
- `chore(site)` — v0.4.2 changelog entry (EN + ZH), release list.

## Verification

- `cargo fmt --check`, `cargo clippy --workspace --all-targets` — clean
- `cargo nextest` orca-runtime lib + orca-tools — 1470/1470
- `node scripts/release/verify-version-sync.mjs` — 0.4.2 synced
- Site build + SEO check, contract validators — pass
- The thread_store change itself: `cargo check --workspace --all-targets` clean; new bounded-time recovery test passes (25k commits in ~1.7s)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Release**
  * Updated the project and package version to v0.4.2.
  * Added the v0.4.2 release notes, installation guidance, compatibility details, and verification information.
  * Published English and Chinese changelog entries.

* **Documentation**
  * Documented improved surface commit recovery with linear scaling and bounded-time regression verification.
  * Updated the production roadmap to reflect the v0.4.2 baseline.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->