### PR TITLE
release: prepare v0.4.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -235,7 +235,7 @@ checksum = "84d7ced0ae9557296835c32bf1b1e02b44c746701f898460fb000d7eaa84f00a"
 
 [[package]]
 name = "blade-deepseek"
-version = "0.4.2"
+version = "0.4.3"
 dependencies = [
  "base64",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,7 +53,7 @@ arboard = { version = "3", features = ["wayland-data-control"] }
 
 [package]
 name = "blade-deepseek"
-version = "0.4.2"
+version = "0.4.3"
 edition = "2024"
 description = "Orca: a DeepSeek-native coding agent"
 license = "MIT"

--- a/docs/production-roadmap.md
+++ b/docs/production-roadmap.md
@@ -131,7 +131,11 @@ two real requests with `second cache_tokens=1024` (the first also reported
 `cache_tokens=1024` because the remote prefix was already warm), confirming a
 non-zero DeepSeek cache hit without exposing credentials.
 
-Current baseline: v0.4.2 indexes surface commit batches by id so
+Current baseline: v0.4.3 shows the running queue task in the TUI queue
+preview and auto-queues submissions made while the session is busy,
+routing them through the durable prompt queue instead of failing the
+handoff, with queue interactions wired into the hosted controller.
+v0.4.2 indexes surface commit batches by id so
 recovery of long recorded surface logs scales linearly instead of
 quadratically, with a bounded-time regression gate. v0.4.1 batches
 provider step commits with deferred

--- a/docs/releases/v0.4.3.md
+++ b/docs/releases/v0.4.3.md
@@ -1,0 +1,45 @@
+# Orca v0.4.3
+
+Patch release: show the running queue task in the TUI queue preview, auto-queue submissions made while the session is busy, and wire the durable prompt queue into the hosted controller.
+
+## Queue running state and busy-submit auto-queueing
+
+- Add a `running` field to the queued-preview snapshot and render the running queue head in the queue preview header.
+- Submissions made while the session is busy now auto-queue through the durable prompt queue instead of being rejected; a backgrounded turn with no background capacity is queued the same way instead of failing the handoff, so the session terminal reports success after the queued turn runs.
+- Bind the prompt queue watcher and interaction handlers into the hosted controller, with queue pause/delete interactions and task interruption wired through the operation controller.
+- Add runtime queue tests covering the new running-state and auto-queue behavior.
+
+## Compatibility
+
+- CLI commands, JSONL session metadata, runtime surface wire formats, npm package names, and release archive layouts remain compatible.
+- No persisted session, goal, or workflow formats change.
+
+## Verification
+
+```bash
+cargo fmt --all -- --check
+cargo check --workspace --tests --jobs 5
+cargo build --workspace --jobs 5
+cargo clippy --workspace --all-targets --locked
+cargo test -p orca-tui --lib -- --test-threads=5
+node scripts/test-validate-runtime-surface-contract.mjs
+node scripts/validate-runtime-surface-contract.mjs
+node scripts/test-validate-windows-platform-boundaries.mjs
+node scripts/validate-windows-platform-boundaries.mjs
+node scripts/release/test-verify-version-sync.mjs
+node scripts/release/test-stage-npm.mjs
+node scripts/release/test-verify-published.mjs
+npm --prefix site run build
+npm --prefix site run check:seo
+git diff --check
+```
+
+The tag-triggered release workflow additionally runs the complete nextest workspace, PTY, Linux, macOS, native Windows x64 and Windows ARM64 gates before publishing the GitHub Release and npm packages.
+
+## Install
+
+```bash
+npm install -g @blade-ai/orca@0.4.3
+```
+
+Or download the platform archive from the GitHub Release and verify the included SHA-256 checksum.

--- a/npm/orca/package.json
+++ b/npm/orca/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@blade-ai/orca",
-  "version": "0.4.2",
+  "version": "0.4.3",
   "description": "Orca CLI: a DeepSeek-native coding agent.",
   "homepage": "https://orcaagent.dev/",
   "license": "MIT",

--- a/site/public/sitemap.xml
+++ b/site/public/sitemap.xml
@@ -2,37 +2,37 @@
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
     <loc>https://orcaagent.dev/</loc>
-    <lastmod>2026-08-23</lastmod>
+    <lastmod>2026-08-25</lastmod>
     <changefreq>weekly</changefreq>
     <priority>1.0</priority>
   </url>
   <url>
     <loc>https://orcaagent.dev/changelog/</loc>
-    <lastmod>2026-08-23</lastmod>
+    <lastmod>2026-08-25</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://orcaagent.dev/terminal-coding-agent/</loc>
-    <lastmod>2026-08-23</lastmod>
+    <lastmod>2026-08-25</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://orcaagent.dev/deepseek-coding-agent/</loc>
-    <lastmod>2026-08-23</lastmod>
+    <lastmod>2026-08-25</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://orcaagent.dev/github/</loc>
-    <lastmod>2026-08-23</lastmod>
+    <lastmod>2026-08-25</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.75</priority>
   </url>
   <url>
     <loc>https://orcaagent.dev/mcp/</loc>
-    <lastmod>2026-08-23</lastmod>
+    <lastmod>2026-08-25</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.75</priority>
   </url>

--- a/site/src/changelog/Changelog.tsx
+++ b/site/src/changelog/Changelog.tsx
@@ -78,6 +78,8 @@ const copy = {
       ],
     },
     summaries: {
+      "v0.4.3":
+        "Shows the running queue head in the TUI queue preview and auto-queues submissions made while the session is busy through the durable prompt queue instead of rejecting them. Backgrounding a turn with no background capacity queues it the same way instead of failing the handoff, so the session completes successfully after the queued turn runs. Queue pause/delete interactions and task interruption are wired into the hosted operation controller.",
       "v0.4.2":
         "Indexes prepared surface commit batches by commit id during surface JSONL log recovery, replacing a linear scan per record so recovery scales linearly instead of quadratically. A bounded-time regression test recovers 25,000 prepared/committed pairs within five seconds.",
       "v0.4.1":
@@ -620,6 +622,8 @@ const copy = {
       ],
     },
     summaries: {
+      "v0.4.3":
+        "TUI 队列预览现在显示正在运行的队列任务，会话繁忙时的提交会自动进入持久化 prompt queue 而不是被拒绝；无后台容量时把当前回合转入后台也会自动排队而不是让会话失败，排队回合运行完成后会话以 success 收尾。队列暂停/删除交互与任务中断已接入 hosted 操作控制器。",
       "v0.4.2":
         "在扫描录制 surface JSONL 日志时按 commit id 建立 prepared batch 索引，替代逐条线性查找，使恢复耗时从平方级降为线性。新增有界时间回归测试：5 秒内恢复 25,000 组 prepared/committed 记录。",
       "v0.4.1":

--- a/site/src/shared.ts
+++ b/site/src/shared.ts
@@ -4,9 +4,16 @@ export const localeStorageKey = "orca-site-locale";
 export const canonicalOrigin = "https://orcaagent.dev";
 export const socialImageUrl = `${canonicalOrigin}/orca-social.png`;
 
-export const releaseVersion = "v0.4.2";
+export const releaseVersion = "v0.4.3";
 
 export const releases = [
+  {
+    version: "v0.4.3",
+    date: "2026-08-25",
+    title: "Queue running state and busy-submit auto-queueing",
+    body: "Shows the running queue head in the TUI queue preview, and auto-queues submissions made while the session is busy through the durable prompt queue instead of rejecting them. A backgrounded turn with no background capacity is queued the same way instead of failing the handoff, so the session completes successfully after the queued turn runs. Queue pause/delete interactions and task interruption are wired into the hosted operation controller.",
+    url: "https://github.com/echoVic/orca-agent/releases/tag/v0.4.3",
+  },
   {
     version: "v0.4.2",
     date: "2026-08-23",


### PR DESCRIPTION
## Summary

Patch release v0.4.3 on top of the queue running-state and busy-submit auto-queueing feature already on main (`feat(orca-tui)` + test adaptation).

- `release: prepare v0.4.3` — Cargo.toml / Cargo.lock / npm `@blade-ai/orca` 0.4.2 → 0.4.3, release notes `docs/releases/v0.4.3.md`, roadmap baseline.
- `chore(site)` — v0.4.3 changelog entry (EN + ZH), release list, sitemap lastmod.

Release notes: `docs/releases/v0.4.3.md`.

## Verification

- `cargo fmt --check`, `cargo clippy --workspace --all-targets` — clean
- `cargo nextest` orca-runtime lib + orca-tools — 1474/1474; orca-tui lib 1217/1217 (incl. the adapted handoff test)
- `node scripts/release/verify-version-sync.mjs` — 0.4.3 synced
- Site build + SEO check, contract validators + self-tests — pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a preview of the currently running queued task.
  * Submissions are now automatically queued when sessions are busy or running in the background.
  * Improved queue handling for hosted operations and task controls.
  * Queued tasks now continue successfully when capacity becomes available.
* **Documentation**
  * Added release notes and changelog entries for version 0.4.3.
  * Updated installation, compatibility, and release verification guidance.
* **Chores**
  * Updated product version metadata to 0.4.3.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->