### PR TITLE
test(runtime): isolate workflow cancel checkpoint contract

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -62,6 +62,10 @@ filter = "package(=orca-runtime) & test(=runtime_host::tests::surface_goal_termi
 threads-required = 2
 
 [[profile.ci.overrides]]
+filter = "package(=orca-runtime) & test(=runtime_host::tests::workflow_cancel_checkpoint_failure_retries_exact_batch_before_signalling_worker)"
+threads-required = 2
+
+[[profile.ci.overrides]]
 filter = "package(=orca-runtime) & binary(=runtime_host) & test(/^(operation_panic_has_one_terminal_and_actor_reclaims_thread_state|panicking_goal_run_settles_outer_turn_and_fails_closed_to_paused|runtime_host_launches_saved_workflow_without_blocking_the_next_turn)$/)"
 threads-required = 2
 


### PR DESCRIPTION
## Summary
- reserve both `ci` nextest worker slots for the workflow cancel checkpoint recovery contract
- prevent release-gate resource contention from turning a sub-second isolated contract into a 120-second timeout

## Evidence
- `v0.4.28` release run `34629552872` timed out this test on all 3 attempts twice
- isolated macOS run passed in 0.74s
- isolated Linux ARM64 run passed in 0.49s
- isolated Linux x86_64 run passed in 2.70s
- 20 concurrent Linux x86_64 runs under a one-CPU limit all passed
- branch Release validation run `34642065211`: Linux test job passed with this override

## Validation
- Runtime Surface Contract: passed
- TUI library gate: passed
- TUI PTY gate: passed
- workspace gate: passed on Ubuntu 22.04


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated continuous integration test settings to run a specific runtime test with two threads, improving consistency during workflow cancellation and retry validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->