### PR TITLE
chore: release v0.4.29

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -235,7 +235,7 @@ checksum = "84d7ced0ae9557296835c32bf1b1e02b44c746701f898460fb000d7eaa84f00a"
 
 [[package]]
 name = "blade-deepseek"
-version = "0.4.28"
+version = "0.4.29"
 dependencies = [
  "base64",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,7 +55,7 @@ arboard = { version = "3", features = ["wayland-data-control"] }
 
 [package]
 name = "blade-deepseek"
-version = "0.4.28"
+version = "0.4.29"
 edition = "2024"
 description = "Orca: a DeepSeek-native coding agent"
 license = "MIT"

--- a/docs/design/runtime-full-access-transition.md
+++ b/docs/design/runtime-full-access-transition.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-Implemented for v0.4.28.
+Implemented for v0.4.29.
 
 ## Contract
 

--- a/docs/releases/v0.4.29.md
+++ b/docs/releases/v0.4.29.md
@@ -1,9 +1,9 @@
-# Orca v0.4.28
+# Orca v0.4.29
 
-> This tagged build was not published. Its changes are included in v0.4.29.
+Inline structured questions, persistent model preferences, truthful Full
+Access transitions, and deterministic release validation.
 
-Inline structured questions, persistent model preferences, and truthful
-Full Access transitions during active tasks.
+This release supersedes the unpublished `v0.4.28` tag.
 
 ## Changes
 
@@ -31,6 +31,9 @@ Full Access transitions during active tasks.
 - Tightens questionnaire layout for terminal character widths, including
   navigation marker spacing, aligned option descriptions, non-duplicated
   headings, and option-count-aware footer hints.
+- Isolates the multi-process workflow cancellation checkpoint contract in the
+  two-thread CI profile so release validation remains deterministic under
+  runner load.
 
 ## Compatibility
 
@@ -65,6 +68,6 @@ npm --prefix site run check:seo
 ## Upgrade
 
 ```bash
-npm install -g @blade-ai/orca@0.4.28
+npm install -g @blade-ai/orca@0.4.29
 orca --version
 ```

--- a/npm/orca/package.json
+++ b/npm/orca/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@blade-ai/orca",
-  "version": "0.4.28",
+  "version": "0.4.29",
   "description": "Orca CLI: a DeepSeek-native coding agent.",
   "homepage": "https://orcaagent.dev/",
   "license": "MIT",

--- a/site/src/changelog/Changelog.tsx
+++ b/site/src/changelog/Changelog.tsx
@@ -1,14 +1,14 @@
 import { useEffect, useState } from "react";
 import {
-    type Locale,
-    type SeoEntry,
-    applySeoHead,
-    canonicalOrigin,
-    detectInitialLocale,
-    links,
-    localeStorageKey,
-    releaseVersion,
-    releases,
+  type Locale,
+  type SeoEntry,
+  applySeoHead,
+  canonicalOrigin,
+  detectInitialLocale,
+  links,
+  localeStorageKey,
+  releaseVersion,
+  releases,
 } from "../shared";
 
 const canonicalUrl = `${canonicalOrigin}/changelog/`;
@@ -78,8 +78,8 @@ const copy = {
       ],
     },
     summaries: {
-      "v0.4.28":
-        "Adds structured inline questionnaires, persistent model and reasoning preferences, and confirmed Full Access transitions that update the active task at the next tool boundary while preserving already-running work.",
+      "v0.4.29":
+        "Adds structured inline questionnaires, persistent model and reasoning preferences, and confirmed Full Access transitions that update the active task at the next tool boundary while preserving already-running work. It also isolates the multi-process workflow cancellation contract for deterministic release validation.",
       "v0.4.27":
         "Adds cache-aware context compaction, durable terminal output paging, file-defined Agents, shared ACP sessions, actionable sandbox and TUI diagnostics, and canonical DeepSeek-V4.1-Flash routing with compatibility aliases.",
       "v0.4.26":
@@ -668,8 +668,8 @@ const copy = {
       ],
     },
     summaries: {
-      "v0.4.28":
-        "新增结构化内联问卷与模型、推理强度持久化；Full Access 经二次确认后从当前任务的下一次工具准入生效，同时保持已运行工具和既有子代理的权限快照不变。",
+      "v0.4.29":
+        "新增结构化内联问卷与模型、推理强度持久化；Full Access 经二次确认后从当前任务的下一次工具准入生效，同时保持已运行工具和既有子代理的权限快照不变；发布门禁同时隔离多进程 workflow cancellation 契约，避免并发调度造成非确定性超时。",
       "v0.4.27":
         "新增缓存感知上下文压缩、持久化终端输出分页、文件化 Agent、共享 ACP 会话、可操作的沙箱与 TUI 诊断，并将 DeepSeek-V4.1-Flash 统一为规范模型名，同时兼容旧名称。",
       "v0.4.26":

--- a/site/src/shared.ts
+++ b/site/src/shared.ts
@@ -4,15 +4,15 @@ export const localeStorageKey = "orca-site-locale";
 export const canonicalOrigin = "https://orcaagent.dev";
 export const socialImageUrl = `${canonicalOrigin}/orca-social.png`;
 
-export const releaseVersion = "v0.4.28";
+export const releaseVersion = "v0.4.29";
 
 export const releases = [
   {
-    version: "v0.4.28",
+    version: "v0.4.29",
     date: "2026-09-11",
     title: "Inline questions and live Full Access",
-    body: "Adds structured inline questionnaires, persistent model and reasoning preferences, and confirmed Full Access transitions that apply to the active task's next tool call without widening work already in flight.",
-    url: "https://github.com/echoVic/orca-agent/releases/tag/v0.4.28",
+    body: "Adds structured inline questionnaires, persistent model and reasoning preferences, and confirmed Full Access transitions that apply to the active task's next tool call without widening work already in flight. The release gate now isolates its multi-process workflow cancellation contract for deterministic publication.",
+    url: "https://github.com/echoVic/orca-agent/releases/tag/v0.4.29",
   },
   {
     version: "v0.4.27",


### PR DESCRIPTION
## Summary
- publish the inline questionnaire, persistent model preferences, and live Full Access transition work as v0.4.29
- supersede the unpublished v0.4.28 tag without rewriting it
- document deterministic release validation for the workflow cancellation checkpoint contract

## Verification
- version synchronization passed
- website production build passed
- SEO validation passed
- branch Release test job passed on Ubuntu 22.04
- six-platform branch build matrix is in progress and being monitored


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added an inline structured questionnaire flow.
  - Model and reasoning-effort preferences are now saved to user settings.
  - Full Access transitions now commit atomically for `full-auto`.
  - Added deterministic validation for multi-process workflow cancellation.

- **Compatibility**
  - Preserved support for legacy single-question, capsule v1/v2, and three-field TUI settings intents.

- **Documentation**
  - Published v0.4.29 release notes and updated the website changelog in English and Chinese.
  - Updated upgrade and verification guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->