### PR TITLE
test(runtime): decouple workflow cancel checkpoint fixture

### DIFF
--- a/crates/orca-runtime/src/runtime_host.rs
+++ b/crates/orca-runtime/src/runtime_host.rs
@@ -26404,7 +26404,7 @@ mod tests {
         std::fs::create_dir_all(&workflow_dir).unwrap();
         std::fs::write(
             workflow_dir.join("retry-cancel.js"),
-            "export const meta = { name: 'retry-cancel', description: 'retry cancel', phases: ['main'] };\nexport default await phase('main', async () => agent('mock_stream_delay_ms 30000'));",
+            "export const meta = { name: 'retry-cancel', description: 'retry cancel', phases: ['main'] };\nexport default await phase('main', async () => new Promise((resolve) => setTimeout(() => resolve('done'), 30000)));",
         )
         .unwrap();
         orca_core::config::folder_trust::set_trust_with_config_dir(

--- a/docs/releases/v0.4.29.md
+++ b/docs/releases/v0.4.29.md
@@ -31,9 +31,10 @@ This release supersedes the unpublished `v0.4.28` tag.
 - Tightens questionnaire layout for terminal character widths, including
   navigation marker spacing, aligned option descriptions, non-duplicated
   headings, and option-count-aware footer hints.
-- Isolates the multi-process workflow cancellation checkpoint contract in the
-  two-thread CI profile so release validation remains deterministic under
-  runner load.
+- Isolates the workflow cancellation checkpoint contract in the two-thread CI
+  profile and keeps its fixture focused on the workflow worker rather than an
+  unrelated nested agent lifecycle, so release validation remains
+  deterministic under runner load.
 
 ## Compatibility
 


### PR DESCRIPTION
## Summary
- keep the workflow cancellation checkpoint test focused on the workflow worker
- remove the unrelated nested agent lifecycle from the timing-sensitive fixture
- document the deterministic release-validation boundary for v0.4.29

## Evidence
- the same pre-fix commit passed Windows x64 in PR run 34646117986 but timed out three times in main run 34646143104
- the failed test was already process-isolated by nextest, so peer-test contention was not the remaining cause
- the updated focused test passed 30 consecutive local runs with zero retries
- all three workflow-cancel unit contracts pass together
- cargo fmt --all -- --check
- node scripts/release/verify-version-sync.mjs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Updated the retry-cancellation test fixture to complete after a 30-second timed wait.

- **Documentation**
  - Revised release notes to describe the two-thread CI cancellation checkpoint contract.
  - Updated the documented fixture scope to focus on the workflow worker rather than the previous multi-process contract.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->