### PR TITLE
fix(runtime): settle workflows alongside active turns

### DIFF
--- a/crates/orca-runtime/src/runtime_actor/thread_actor_operation.rs
+++ b/crates/orca-runtime/src/runtime_actor/thread_actor_operation.rs
@@ -2881,6 +2881,7 @@ impl ThreadActor {
         let typed_workflow = TypedWorkflowBackground {
             fence: background_fence,
             task_id,
+            task_registry: task_registry.clone(),
             workflow_run_id: workflow_run_id.clone(),
             tool_use_id: surface_tool_use_id,
         };

--- a/crates/orca-runtime/src/runtime_actor/thread_actor_task_workflow.rs
+++ b/crates/orca-runtime/src/runtime_actor/thread_actor_task_workflow.rs
@@ -1127,14 +1127,31 @@ impl ThreadActor {
         shutdown_reason: Option<surface::SurfaceShutdownReason>,
     ) -> Result<(), RuntimeHostError> {
         let operation_id = typed.fence.operation_fence.operation_id.clone();
-        let mut pending = self.prepare_typed_workflow_completion(typed, shutdown_reason)?;
+        let mut pending =
+            match self.prepare_typed_workflow_completion(typed.clone(), shutdown_reason.clone()) {
+                Ok(pending) => pending,
+                Err(error) => {
+                    self.background_controller.retain_workflow_completion(
+                        operation_id,
+                        PendingTypedWorkflowCompletion::Preparation {
+                            typed,
+                            shutdown_reason,
+                            retry_at: tokio::time::Instant::now()
+                                + SURFACE_CAPABILITY_LOSS_RETRY_INTERVAL,
+                        },
+                    );
+                    return Err(error);
+                }
+            };
         match self.settle_typed_workflow_completion(&mut pending) {
             Ok(()) => Ok(()),
             Err(error) => {
                 pending.retry_at =
                     tokio::time::Instant::now() + SURFACE_CAPABILITY_LOSS_RETRY_INTERVAL;
-                self.background_controller
-                    .retain_workflow_completion(operation_id, pending);
+                self.background_controller.retain_workflow_completion(
+                    operation_id,
+                    PendingTypedWorkflowCompletion::Completion(pending),
+                );
                 Err(error)
             }
         }
@@ -1144,7 +1161,7 @@ impl ThreadActor {
         &mut self,
         typed: TypedWorkflowBackground,
         shutdown_reason: Option<surface::SurfaceShutdownReason>,
-    ) -> Result<PendingTypedWorkflowCompletion, RuntimeHostError> {
+    ) -> Result<PreparedTypedWorkflowCompletion, RuntimeHostError> {
         let snapshot = self.resident_surface.coordinator.state().snapshot().clone();
         let task = snapshot
             .tasks
@@ -1433,7 +1450,7 @@ impl ThreadActor {
             ),
         ]);
         let completion_batch = self.surface_event_batch_with_commit_id(completion_events, None);
-        Ok(PendingTypedWorkflowCompletion {
+        Ok(PreparedTypedWorkflowCompletion {
             typed,
             shutdown_reason,
             operation_id: operation_id.clone(),
@@ -1452,7 +1469,7 @@ impl ThreadActor {
 
     pub(super) fn settle_typed_workflow_completion(
         &mut self,
-        pending: &mut PendingTypedWorkflowCompletion,
+        pending: &mut PreparedTypedWorkflowCompletion,
     ) -> Result<(), RuntimeHostError> {
         if pending.stage == TypedWorkflowCompletionStage::Completion {
             if self.resident_surface.coordinator.has_incomplete_batch()
@@ -1587,17 +1604,57 @@ impl ThreadActor {
         let key = BackgroundRetryKey::WorkflowCompletion(operation_id.clone());
         let Some(BackgroundRetryEffect::WorkflowCompletion {
             operation_id,
-            mut pending,
+            pending,
         }) = self.background_controller.begin_retry(&key)
         else {
             return;
         };
-        let resolution = if self.settle_typed_workflow_completion(&mut pending).is_err() {
-            BackgroundRetryResolution::RetryAt(
-                tokio::time::Instant::now() + SURFACE_CAPABILITY_LOSS_RETRY_INTERVAL,
-            )
-        } else {
-            BackgroundRetryResolution::Settled
+        let retry_at = tokio::time::Instant::now() + SURFACE_CAPABILITY_LOSS_RETRY_INTERVAL;
+        let (pending, resolution) = match pending {
+            PendingTypedWorkflowCompletion::Preparation {
+                typed,
+                shutdown_reason,
+                retry_at: previous_retry_at,
+            } => match self
+                .prepare_typed_workflow_completion(typed.clone(), shutdown_reason.clone())
+            {
+                Ok(mut completion) => {
+                    let resolution = if self
+                        .settle_typed_workflow_completion(&mut completion)
+                        .is_err()
+                    {
+                        BackgroundRetryResolution::RetryAt(retry_at)
+                    } else {
+                        BackgroundRetryResolution::Settled
+                    };
+                    (
+                        PendingTypedWorkflowCompletion::Completion(completion),
+                        resolution,
+                    )
+                }
+                Err(_) => (
+                    PendingTypedWorkflowCompletion::Preparation {
+                        typed,
+                        shutdown_reason,
+                        retry_at: previous_retry_at,
+                    },
+                    BackgroundRetryResolution::RetryAt(retry_at),
+                ),
+            },
+            PendingTypedWorkflowCompletion::Completion(mut completion) => {
+                let resolution = if self
+                    .settle_typed_workflow_completion(&mut completion)
+                    .is_err()
+                {
+                    BackgroundRetryResolution::RetryAt(retry_at)
+                } else {
+                    BackgroundRetryResolution::Settled
+                };
+                (
+                    PendingTypedWorkflowCompletion::Completion(completion),
+                    resolution,
+                )
+            }
         };
         self.background_controller.resolve_retry(
             BackgroundRetryEffect::WorkflowCompletion {

--- a/crates/orca-runtime/src/runtime_actor/thread_actor_task_workflow.rs
+++ b/crates/orca-runtime/src/runtime_actor/thread_actor_task_workflow.rs
@@ -1126,6 +1126,25 @@ impl ThreadActor {
         typed: TypedWorkflowBackground,
         shutdown_reason: Option<surface::SurfaceShutdownReason>,
     ) -> Result<(), RuntimeHostError> {
+        let operation_id = typed.fence.operation_fence.operation_id.clone();
+        let mut pending = self.prepare_typed_workflow_completion(typed, shutdown_reason)?;
+        match self.settle_typed_workflow_completion(&mut pending) {
+            Ok(()) => Ok(()),
+            Err(error) => {
+                pending.retry_at =
+                    tokio::time::Instant::now() + SURFACE_CAPABILITY_LOSS_RETRY_INTERVAL;
+                self.background_controller
+                    .retain_workflow_completion(operation_id, pending);
+                Err(error)
+            }
+        }
+    }
+
+    pub(super) fn prepare_typed_workflow_completion(
+        &mut self,
+        typed: TypedWorkflowBackground,
+        shutdown_reason: Option<surface::SurfaceShutdownReason>,
+    ) -> Result<PendingTypedWorkflowCompletion, RuntimeHostError> {
         let snapshot = self.resident_surface.coordinator.state().snapshot().clone();
         let task = snapshot
             .tasks
@@ -1143,16 +1162,9 @@ impl ThreadActor {
             .ok_or_else(|| RuntimeHostError::ThreadStartFailed {
                 message: "typed workflow disappeared before completion".to_string(),
             })?;
-        let record = self
-            .state
-            .as_ref()
-            .and_then(|state| {
-                state
-                    .thread
-                    .session()
-                    .task_registry()
-                    .get(typed.task_id.as_str())
-            })
+        let record = typed
+            .task_registry
+            .get(typed.task_id.as_str())
             .ok_or_else(|| RuntimeHostError::ThreadStartFailed {
                 message: "workflow task registry record disappeared before completion".to_string(),
             })?;
@@ -1421,8 +1433,9 @@ impl ThreadActor {
             ),
         ]);
         let completion_batch = self.surface_event_batch_with_commit_id(completion_events, None);
-        let mut pending = PendingTypedWorkflowCompletion {
+        Ok(PendingTypedWorkflowCompletion {
             typed,
+            shutdown_reason,
             operation_id: operation_id.clone(),
             finalize_intent_id,
             terminal_commit_id,
@@ -1432,18 +1445,9 @@ impl ThreadActor {
             terminal_batch: None,
             terminal_value: None,
             stage: TypedWorkflowCompletionStage::Completion,
+            rebuild_after_foreign_incomplete: false,
             retry_at: tokio::time::Instant::now(),
-        };
-        match self.settle_typed_workflow_completion(&mut pending) {
-            Ok(()) => Ok(()),
-            Err(error) => {
-                pending.retry_at =
-                    tokio::time::Instant::now() + SURFACE_CAPABILITY_LOSS_RETRY_INTERVAL;
-                self.background_controller
-                    .retain_workflow_completion(operation_id, pending);
-                Err(error)
-            }
-        }
+        })
     }
 
     pub(super) fn settle_typed_workflow_completion(
@@ -1451,6 +1455,35 @@ impl ThreadActor {
         pending: &mut PendingTypedWorkflowCompletion,
     ) -> Result<(), RuntimeHostError> {
         if pending.stage == TypedWorkflowCompletionStage::Completion {
+            if self.resident_surface.coordinator.has_incomplete_batch()
+                && !self
+                    .resident_surface
+                    .coordinator
+                    .incomplete_batch_is(&pending.completion_batch)
+            {
+                pending.rebuild_after_foreign_incomplete = true;
+                return Err(RuntimeHostError::ThreadStartFailed {
+                    message:
+                        "typed workflow completion is waiting for another prepared surface batch"
+                            .to_string(),
+                });
+            }
+            let current_cursor = self
+                .resident_surface
+                .coordinator
+                .state()
+                .snapshot()
+                .cursor
+                .clone();
+            if !self.resident_surface.coordinator.has_incomplete_batch()
+                && (pending.rebuild_after_foreign_incomplete
+                    || pending.completion_batch.cursor_before != current_cursor)
+            {
+                *pending = self.prepare_typed_workflow_completion(
+                    pending.typed.clone(),
+                    pending.shutdown_reason.clone(),
+                )?;
+            }
             self.resident_surface
                 .coordinator
                 .commit_workflow_background_stop_batch(
@@ -1464,7 +1497,30 @@ impl ThreadActor {
                 })?;
             pending.stage = TypedWorkflowCompletionStage::Terminal;
         }
-        if pending.terminal_batch.is_none() {
+        if self.resident_surface.coordinator.has_incomplete_batch()
+            && !pending
+                .terminal_batch
+                .as_ref()
+                .is_some_and(|batch| self.resident_surface.coordinator.incomplete_batch_is(batch))
+        {
+            return Err(RuntimeHostError::ThreadStartFailed {
+                message: "typed workflow terminal is waiting for another prepared surface batch"
+                    .to_string(),
+            });
+        }
+        let current_cursor = self
+            .resident_surface
+            .coordinator
+            .state()
+            .snapshot()
+            .cursor
+            .clone();
+        let terminal_batch_is_stale = pending
+            .terminal_batch
+            .as_ref()
+            .is_some_and(|batch| batch.cursor_before != current_cursor)
+            && !self.resident_surface.coordinator.has_incomplete_batch();
+        if pending.terminal_batch.is_none() || terminal_batch_is_stale {
             let terminal_batch = self.surface_event_batch_with_commit_id(
                 vec![(
                     surface::SurfaceScope::Background {

--- a/crates/orca-runtime/src/runtime_host.rs
+++ b/crates/orca-runtime/src/runtime_host.rs
@@ -14136,7 +14136,17 @@ enum TypedWorkflowCompletionStage {
 }
 
 #[derive(Clone)]
-struct PendingTypedWorkflowCompletion {
+enum PendingTypedWorkflowCompletion {
+    Preparation {
+        typed: TypedWorkflowBackground,
+        shutdown_reason: Option<surface::SurfaceShutdownReason>,
+        retry_at: tokio::time::Instant,
+    },
+    Completion(PreparedTypedWorkflowCompletion),
+}
+
+#[derive(Clone)]
+struct PreparedTypedWorkflowCompletion {
     typed: TypedWorkflowBackground,
     shutdown_reason: Option<surface::SurfaceShutdownReason>,
     operation_id: surface::SurfaceOperationId,
@@ -14154,11 +14164,20 @@ struct PendingTypedWorkflowCompletion {
 
 impl ScheduledBackgroundRetry for PendingTypedWorkflowCompletion {
     fn retry_at(&self) -> tokio::time::Instant {
-        self.retry_at
+        match self {
+            Self::Preparation { retry_at, .. } => *retry_at,
+            Self::Completion(pending) => pending.retry_at,
+        }
     }
 
     fn defer_until(&mut self, retry_at: tokio::time::Instant) {
-        self.retry_at = retry_at;
+        match self {
+            Self::Preparation {
+                retry_at: pending_retry_at,
+                ..
+            } => *pending_retry_at = retry_at,
+            Self::Completion(pending) => pending.retry_at = retry_at,
+        }
     }
 }
 

--- a/crates/orca-runtime/src/runtime_host.rs
+++ b/crates/orca-runtime/src/runtime_host.rs
@@ -14022,6 +14022,7 @@ impl ManagedBackgroundTask<TypedWorkflowBackground, TypedProviderBackground>
 struct TypedWorkflowBackground {
     fence: surface::SurfaceBackgroundFence,
     task_id: surface::SurfaceTaskId,
+    task_registry: TaskRegistry,
     workflow_run_id: surface::SurfaceWorkflowRunId,
     tool_use_id: surface::SurfaceToolCallId,
 }
@@ -14137,6 +14138,7 @@ enum TypedWorkflowCompletionStage {
 #[derive(Clone)]
 struct PendingTypedWorkflowCompletion {
     typed: TypedWorkflowBackground,
+    shutdown_reason: Option<surface::SurfaceShutdownReason>,
     operation_id: surface::SurfaceOperationId,
     finalize_intent_id: surface::SurfaceFinalizeIntentId,
     terminal_commit_id: surface::SurfaceCommitId,
@@ -14146,6 +14148,7 @@ struct PendingTypedWorkflowCompletion {
     terminal_batch: Option<surface::SurfaceCommitBatch>,
     terminal_value: Option<surface::OperationTerminalAtCursor>,
     stage: TypedWorkflowCompletionStage,
+    rebuild_after_foreign_incomplete: bool,
     retry_at: tokio::time::Instant,
 }
 
@@ -26549,13 +26552,6 @@ mod tests {
             Some(&foreground.operation_id),
             "background recovery must not cancel the active foreground operation"
         );
-        foreground_release_tx
-            .send(())
-            .expect("release foreground after background cancellation");
-        let _ = attachment
-            .client
-            .wait_operation_terminal(surface_request_id(), foreground.operation_id)
-            .expect("wait foreground terminal");
         let terminal = attachment
             .client
             .wait_operation_terminal(surface_request_id(), workflow_operation_id.clone())
@@ -26571,6 +26567,13 @@ mod tests {
                 }
             }
         ));
+        foreground_release_tx
+            .send(())
+            .expect("release foreground after background cancellation");
+        let _ = attachment
+            .client
+            .wait_operation_terminal(surface_request_id(), foreground.operation_id)
+            .expect("wait foreground terminal");
         let recovered =
             surface::JsonlSurfaceCommitLedger::new(transcript_path, initial_cursor.clone())
                 .recover_batches()

--- a/docs/releases/v0.4.29.md
+++ b/docs/releases/v0.4.29.md
@@ -31,10 +31,10 @@ This release supersedes the unpublished `v0.4.28` tag.
 - Tightens questionnaire layout for terminal character widths, including
   navigation marker spacing, aligned option descriptions, non-duplicated
   headings, and option-count-aware footer hints.
-- Isolates the workflow cancellation checkpoint contract in the two-thread CI
-  profile and keeps its fixture focused on the workflow worker rather than an
-  unrelated nested agent lifecycle, so release validation remains
-  deterministic under runner load.
+- Decouples workflow completion from foreground turn state ownership and
+  rebuilds cursor-bound completion batches after concurrent checkpoint
+  recovery. The cancellation contract now keeps the foreground turn active
+  until the background workflow publishes its terminal state.
 
 ## Compatibility
 


### PR DESCRIPTION
## Summary
- keep the workflow task registry with the typed background owner so completion does not depend on foreground actor state
- rebuild workflow completion and terminal batches after another prepared batch advances the surface cursor
- make the cancellation checkpoint test publish the workflow terminal while the foreground turn remains active

## Validation
- 30 consecutive local exact-test runs
- 3 neighboring workflow cancellation tests
- 3 native Windows x64 runs with 20 exact-test attempts each (60/60)
- cargo fmt --all -- --check
- node scripts/release/verify-version-sync.mjs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved workflow completion handling during cancellation and recovery.
  - Foreground operations now remain active until background workflows publish their terminal state.
  - Improved recovery for incomplete or stale completion batches after concurrent checkpoint activity.
  - Preserved eligible workflow completion retries after preparation failures.
  - Improved task registry handling for typed workflows.

- **Documentation**
  - Clarified workflow cancellation and checkpoint completion behavior in the release documentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->