### PR TITLE
test(windows): isolate release stability gates

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -37,8 +37,25 @@ threads-required = 2
 filter = "package(=orca-tools) & test(/^bash::tests::(streaming_reports_output_chunks_and_final_result|streaming_large_unterminated_output_is_bounded_before_result_truncation|bash_commands_receive_eof_on_stdin_instead_of_inheriting_terminal|streaming_respects_shell_timeout_and_returns_partial_output|noisy_streaming_timeout_does_not_deadlock_reader_shutdown|bash_wait_observes_cancel_callback|bash_wait_preserves_one_shot_cancel_observation|streaming_bash_wait_observes_cancel_callback|noisy_streaming_cancel_does_not_deadlock_reader_shutdown)$/)"
 threads-required = 2
 
+# Cold Windows runners need exclusive I/O and process capacity for these
+# durability and multi-process contracts.
 [[profile.ci.overrides]]
 filter = "package(=orca-runtime) & binary(=task_output_store)"
+threads-required = 2
+slow-timeout = { period = "120s", terminate-after = 2 }
+
+[[profile.ci.overrides]]
+filter = "package(=orca-runtime) & test(=task_output::tests::persistent_store_keeps_output_before_memory_eviction_and_after_reopen)"
+threads-required = 2
+slow-timeout = { period = "120s", terminate-after = 2 }
+
+[[profile.ci.overrides]]
+filter = "binary(=subagent_recovery_contract) & test(/^(custom_agent_exec_continue_recovers_original_owner_and_rejects_other_sessions|detached_custom_agent_recovers_across_modes_and_rejects_other_sessions)$/)"
+threads-required = 2
+slow-timeout = { period = "120s", terminate-after = 2 }
+
+[[profile.ci.overrides]]
+filter = "binary(=exec_jsonl) & test(=exec_post_model_hook_observes_usage_environment)"
 threads-required = 2
 
 [[profile.ci.overrides]]

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -142,6 +142,7 @@ jobs:
             binary: orca.exe
             archive: zip
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 90
     steps:
       - uses: actions/checkout@v5
         with:

--- a/tests/exec_jsonl.rs
+++ b/tests/exec_jsonl.rs
@@ -251,6 +251,10 @@ fn exec_post_model_hook_observes_usage_environment() {
         home.path().join("config.toml"),
         format!(
             r#"
+update_check = false
+auto_memory = false
+mode = "full-auto"
+
 [[hooks]]
 event = "post_model_call"
 command = {}


### PR DESCRIPTION
## What changed

- reserve both `ci` nextest slots for the Windows-heavy subagent recovery, hook, and durable output contracts
- give the durable output and recovery contracts a 240-second nextest budget instead of the generic 120-second budget
- isolate the post-model hook fixture from update, memory, and sandbox probing side effects
- cap release build matrix jobs at 90 minutes

## Root cause

Release dry-run 34679943220 ran without a Rust cache. Three I/O- and process-heavy Windows tests exceeded the generic 120-second nextest timeout on all three attempts, while two additional tests required a retry. The same commit passed on the cached main Windows run, where the recovery contracts took 92-94 seconds and the durable output contract took 57 seconds. The tests were competing for the two-slot CI pool or exercising unrelated sandbox/update setup.

## Impact

No runtime behavior or assertions are weakened. The affected contracts retain full coverage, but resource-heavy cases run with exclusive capacity and an explicit timeout that accommodates cold Windows runners. Release jobs also gain a finite upper bound.

## Validation

- `cargo fmt --all -- --check`
- `actionlint .github/workflows/release.yml`
- `git diff --check`
- focused `ci` nextest selection: 5/5 passed locally, first attempt, no retries


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Updated automated test execution settings to improve consistency on slower environments.
  - Standardized test scenarios with explicit runtime configuration for predictable results.
  - Added safeguards for long-running test cases.

- **Chores**
  - Added a 90-minute limit to release build jobs, preventing stalled builds from running indefinitely.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->