### PR TITLE
[codex] Stabilize TUI surface activation waits

### DIFF
--- a/crates/orca-tui/src/operation_controller.rs
+++ b/crates/orca-tui/src/operation_controller.rs
@@ -1147,6 +1147,19 @@ impl TuiSurfaceTaskControl {
         self.lock_hosted().surface_active.is_some()
     }
 
+    #[cfg(test)]
+    pub(crate) fn wait_for_surface_active(&self, timeout: Duration) -> bool {
+        let hosted = self.lock_hosted();
+        let (hosted, _) = self
+            .hosted
+            .changed
+            .wait_timeout_while(hosted, timeout, |hosted| {
+                hosted.surface_active.is_none() && !hosted.shutdown
+            })
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        hosted.surface_active.is_some()
+    }
+
     pub(crate) fn install_focused_child_surface(
         &self,
         client: orca_runtime::surface::RuntimeSurfaceClientHandle,

--- a/crates/orca-tui/src/surface_client.rs
+++ b/crates/orca-tui/src/surface_client.rs
@@ -2864,6 +2864,15 @@ fn detach(surface: &RuntimeSurfaceHandle, client: &RuntimeSurfaceClientHandle) {
 mod tests {
     use super::*;
 
+    const TEST_SURFACE_ACTIVATION_TIMEOUT: Duration = Duration::from_secs(10);
+
+    fn assert_surface_active(controller: &TuiSurfaceTaskControl, context: &str) {
+        assert!(
+            controller.wait_for_surface_active(TEST_SURFACE_ACTIVATION_TIMEOUT),
+            "{context}"
+        );
+    }
+
     #[test]
     fn task_transcript_surface_errors_remain_typed_and_path_free() {
         let result =
@@ -3388,11 +3397,10 @@ mod tests {
             );
             let _ = result_tx.send(result);
         });
-        let deadline = Instant::now() + Duration::from_secs(2);
-        while !controller.has_surface_active() && Instant::now() < deadline {
-            std::thread::sleep(Duration::from_millis(5));
-        }
-        assert!(controller.has_surface_active());
+        assert_surface_active(
+            &controller,
+            "typed cancellation must install the TUI controller",
+        );
 
         let _ = controller.interrupt_current();
         let outcome = result_rx
@@ -3445,11 +3453,10 @@ mod tests {
             );
             let _ = result_tx.send(result);
         });
-        let deadline = Instant::now() + Duration::from_secs(2);
-        while !controller.has_surface_active() && Instant::now() < deadline {
-            std::thread::sleep(Duration::from_millis(5));
-        }
-        assert!(controller.has_surface_active());
+        assert_surface_active(
+            &controller,
+            "typed background turn must install the TUI controller",
+        );
         let first_delta_deadline = Instant::now() + Duration::from_secs(2);
         loop {
             if event_rx.try_iter().any(|event| {
@@ -3852,13 +3859,9 @@ mod tests {
             );
             let _ = foreground_tx.send(result);
         });
-        let active_deadline = Instant::now() + Duration::from_secs(2);
-        while !controller.has_surface_active() && Instant::now() < active_deadline {
-            std::thread::sleep(Duration::from_millis(5));
-        }
-        assert!(
-            controller.has_surface_active(),
-            "foreground attach must install the TUI controller"
+        assert_surface_active(
+            &controller,
+            "foreground attach must install the TUI controller",
         );
         assert!(controller.request_background_current());
         let projection = match foreground_rx.recv_timeout(Duration::from_secs(2)) {
@@ -3928,11 +3931,10 @@ mod tests {
             );
             let _ = result_tx.send(result);
         });
-        let deadline = Instant::now() + Duration::from_secs(2);
-        while !controller.has_surface_active() && Instant::now() < deadline {
-            std::thread::sleep(Duration::from_millis(5));
-        }
-        assert!(controller.has_surface_active());
+        assert_surface_active(
+            &controller,
+            "typed approval background must install the TUI controller",
+        );
         assert!(controller.request_background_current());
         let outcome = result_rx
             .recv_timeout(Duration::from_secs(2))
@@ -4648,11 +4650,10 @@ mod tests {
             );
             let _ = result_tx.send(result);
         });
-        let deadline = Instant::now() + Duration::from_secs(2);
-        while !controller.has_surface_active() && Instant::now() < deadline {
-            std::thread::sleep(Duration::from_millis(5));
-        }
-        assert!(controller.has_surface_active());
+        assert_surface_active(
+            &controller,
+            "typed background owner must install the TUI controller",
+        );
         assert!(controller.request_background_current());
         let outcome = result_rx
             .recv_timeout(Duration::from_secs(2))
@@ -4742,11 +4743,10 @@ mod tests {
             );
             let _ = result_tx.send(result);
         });
-        let deadline = Instant::now() + Duration::from_secs(2);
-        while !controller.has_surface_active() && Instant::now() < deadline {
-            std::thread::sleep(Duration::from_millis(5));
-        }
-        assert!(controller.has_surface_active());
+        assert_surface_active(
+            &controller,
+            "typed cancellation restart must install the TUI controller",
+        );
         let _ = controller.interrupt_current();
 
         let cancelled = result_rx


### PR DESCRIPTION
## What changed

- added a test-only condition-variable wait for `TuiSurfaceTaskControl` activation
- replaced all six fixed two-second polling loops in the typed surface tests
- retained a ten-second upper bound only for deadlock detection

## Root cause

The `v0.4.29` Windows x64 release gate completed successfully only after nextest retried `typed_ordinary_turn_interrupt_uses_surface_cancel`. On the first attempt, the cold runner needed more than two seconds to install the active surface, so the test failed at `assert!(controller.has_surface_active())`. The runtime already notifies a condition variable when activation state changes; the tests were polling instead of waiting on that signal.

## Impact

This removes scheduler-speed dependence from the affected cancellation/background tests without changing production execution or cancellation semantics.

## Verification

- `cargo fmt --all -- --check`
- target test: 30/30 consecutive passes with `--retries 0`
- six affected surface scenarios: 6/6 passes with `--retries 0`
- `cargo nextest run -p orca-tui --lib --profile ci-serial --retries 0`: 1342/1342 passed
- `cargo clippy --workspace --all-targets --locked -j 1`: passed with existing warnings


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Improved surface activation test reliability by replacing polling-based checks with condition-based waiting.
  - Added timeout handling for activation checks, including graceful handling of shutdown scenarios.
  - Updated multiple surface-related tests to use the more consistent activation assertion helper.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->