### PR TITLE
[codex] Stabilize background terminal proofs and release promotion

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,14 +12,11 @@ on:
         default: "0.1.0"
 
 permissions:
+  actions: read
   contents: read
 
 jobs:
   test:
-    # Ubuntu 24.04's hosted AppArmor profile blocks the unprivileged user
-    # namespaces required by bubblewrap. Pin the behavioral gate to 22.04 so
-    # the release path exercises the real namespace backend; production still
-    # fails closed when a host cannot enforce the same boundary.
     runs-on: ubuntu-22.04
     timeout-minutes: 45
     steps:
@@ -30,32 +27,54 @@ jobs:
       - uses: actions/setup-node@v5
         with:
           node-version: 22
+      - name: Verify tagged commit passed main gates
+        if: github.ref_type == 'tag'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          git fetch origin main --depth=1
+          test "$(git rev-parse origin/main)" = "$GITHUB_SHA"
+          checks="$(gh api "repos/${GITHUB_REPOSITORY}/commits/${GITHUB_SHA}/check-runs")"
+          for name in validate native-x64 native-arm64; do
+            jq -e --arg name "$name" \
+              'any(.check_runs[]; .name == $name and .conclusion == "success" and .app.slug == "github-actions")' \
+              <<<"$checks" >/dev/null
+          done
       - uses: dtolnay/rust-toolchain@stable
+        if: github.event_name == 'workflow_dispatch'
       - uses: taiki-e/install-action@nextest
+        if: github.event_name == 'workflow_dispatch'
       - uses: Swatinem/rust-cache@v2
+        if: github.event_name == 'workflow_dispatch'
       - name: Install test runtime dependencies
+        if: github.event_name == 'workflow_dispatch'
         run: |
           sudo apt-get update
           sudo apt-get install -y ripgrep bubblewrap
       - name: Validate runtime surface contract
+        if: github.event_name == 'workflow_dispatch'
         run: |
           node scripts/test-validate-runtime-surface-contract.mjs
           node scripts/validate-runtime-surface-contract.mjs
           cargo metadata --locked --format-version 1 > /dev/null
           cargo test -p orca-tui runtime_surface_contract --lib --locked
       - name: Validate repository adapters and hygiene
+        if: github.event_name == 'workflow_dispatch'
         run: |
           python3 -m unittest discover -s terminal_bench -p 'test_*.py' -v
           node scripts/test-repository-hygiene.mjs
       - name: Run TUI library gate
+        if: github.event_name == 'workflow_dispatch'
         env:
           RUST_BACKTRACE: "1"
         run: cargo nextest run -p orca-tui --lib --locked --profile ci-serial
       - name: Run TUI PTY contract gate
+        if: github.event_name == 'workflow_dispatch'
         env:
           RUST_BACKTRACE: "1"
         run: cargo nextest run --test tui_pty_contract --locked --profile ci-serial
       - name: Run workspace gate
+        if: github.event_name == 'workflow_dispatch'
         env:
           RUST_BACKTRACE: "1"
         run: |
@@ -160,7 +179,7 @@ jobs:
           sudo apt-get install -y gcc-aarch64-linux-gnu
           echo "CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER=aarch64-linux-gnu-gcc" >> "$GITHUB_ENV"
       - name: Run native Windows x64 behavior gates
-        if: matrix.target == 'x86_64-pc-windows-msvc'
+        if: github.event_name == 'workflow_dispatch' && matrix.target == 'x86_64-pc-windows-msvc'
         shell: pwsh
         env:
           RUST_BACKTRACE: "1"
@@ -179,7 +198,7 @@ jobs:
           cargo nextest run --test tui_pty_contract --locked --profile ci-serial --no-tests=pass
           cargo nextest run --workspace --all-targets --locked --profile ci --no-fail-fast
       - name: Run native Windows ARM64 behavior gates
-        if: matrix.target == 'aarch64-pc-windows-msvc'
+        if: github.event_name == 'workflow_dispatch' && matrix.target == 'aarch64-pc-windows-msvc'
         shell: pwsh
         run: |
           $ErrorActionPreference = "Stop"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,6 +13,7 @@ on:
 
 permissions:
   actions: read
+  checks: read
   contents: read
 
 jobs:

--- a/crates/orca-runtime/src/runtime_actor/thread_actor_interaction.rs
+++ b/crates/orca-runtime/src/runtime_actor/thread_actor_interaction.rs
@@ -5273,6 +5273,9 @@ impl ThreadActor {
         let terminal = surface::OperationTerminal::Cancelled {
             reason: surface::CancelReason::User,
         };
+        let current_snapshot = self.resident_surface.coordinator.state().snapshot();
+        let completion_proof =
+            Self::surface_completion_proof(&current_snapshot, &operation, &terminal, None)?;
         let terminal_record = surface::OperationTerminalRecord {
             operation_id: operation.operation_id.clone(),
             finalize_intent_id: finalize_intent_id.clone(),
@@ -5285,9 +5288,7 @@ impl ThreadActor {
             },
             source_diagnostic_digest: None,
             settlement_receipts: Vec::new(),
-            completion_proof: surface::SurfaceOperationCompletionProof::unverified(
-                "interaction terminal has no verifier proof",
-            ),
+            completion_proof,
             committed_at: surface::UnixMillis::new(0),
         };
         let projection = prepare_main_session_task_terminal_projection(

--- a/crates/orca-runtime/src/runtime_actor/thread_actor_task_workflow.rs
+++ b/crates/orca-runtime/src/runtime_actor/thread_actor_task_workflow.rs
@@ -860,6 +860,14 @@ impl ThreadActor {
             .is_some_and(|batch| batch.cursor_before != current_cursor)
             && !self.resident_surface.coordinator.has_incomplete_batch();
         if pending.terminal_batch.is_none() || terminal_batch_is_stale {
+            let snapshot = self.resident_surface.coordinator.state().snapshot().clone();
+            let operation = Self::surface_operation_record(&snapshot, &pending.operation_id)
+                .cloned()
+                .ok_or_else(|| RuntimeHostError::ThreadStartFailed {
+                    message: "typed provider operation disappeared before terminal".to_string(),
+                })?;
+            let completion_proof =
+                Self::surface_completion_proof(&snapshot, &operation, &pending.terminal, None)?;
             let terminal_batch = self.surface_event_batch_with_commit_id(
                 vec![(
                     surface::SurfaceScope::Background {
@@ -873,9 +881,7 @@ impl ThreadActor {
                             usage: pending.usage.clone(),
                             source_diagnostic_digest: None,
                             settlement_receipts: Vec::new(),
-                            completion_proof: surface::SurfaceOperationCompletionProof::unverified(
-                                "background workflow terminal has no verifier proof",
-                            ),
+                            completion_proof: completion_proof.clone(),
                             committed_at: surface::UnixMillis::new(
                                 chrono::Utc::now().timestamp_millis(),
                             ),
@@ -887,9 +893,7 @@ impl ThreadActor {
             pending.terminal_value = Some(surface::OperationTerminalAtCursor {
                 operation_id: pending.operation_id.clone(),
                 terminal: pending.terminal.clone(),
-                completion_proof: surface::SurfaceOperationCompletionProof::unverified(
-                    "background workflow terminal has no verifier proof",
-                ),
+                completion_proof,
                 cursor: terminal_batch.cursor_after.clone(),
                 commit_class: terminal_batch.commit_class.clone(),
                 batch_digest: terminal_batch.batch_digest.clone(),

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -61,6 +61,13 @@ broad workspace run passes. Clippy warnings are tracked separately from release
 failures; do not hide them with a global allow, and do not turn a patch release
 into an unrelated public-API cleanup merely to satisfy a newer toolchain lint.
 
+For a tag-triggered release, `release.yml` verifies that the tagged commit is
+the current `origin/main` commit and that the `Runtime Surface Contract`
+`validate` check plus the Windows `native-x64` and `native-arm64` checks already
+succeeded for that exact SHA. It then reuses that evidence instead of rerunning
+the same full suites. A manual `workflow_dispatch` remains the full release
+dry-run path and executes every gate above.
+
 ### 5. Update the website
 
 Edit `site/src/shared.ts`:
@@ -103,7 +110,7 @@ version already exists or points elsewhere, stop and choose a new version.
 
 The `release.yml` workflow is the sole publisher. It triggers on the tag push
 and:
-1. Runs tests
+1. Verifies the tagged SHA already passed the required `main` checks
 2. Builds binaries for all six targets, including native Windows x64 and ARM64
 3. Creates a GitHub Release with binary assets
 4. Stages, smoke-tests, and publishes npm packages

--- a/scripts/test-validate-windows-platform-boundaries.mjs
+++ b/scripts/test-validate-windows-platform-boundaries.mjs
@@ -923,6 +923,10 @@ assert.ok(
 for (const gate of [releaseWindowsX64Gate[0], releaseWindowsArm64Gate[0]]) {
   assert.ok(gate.includes("shell: pwsh"), "release Windows behavior gates must use PowerShell 7");
   assert.ok(
+    gate.includes("github.event_name == 'workflow_dispatch'"),
+    "release Windows behavior gates must run only for explicit dry-run validation",
+  );
+  assert.ok(
     gate.includes('$ErrorActionPreference = "Stop"') &&
       gate.includes("$PSNativeCommandUseErrorActionPreference = $true"),
     "release Windows behavior gates must fail on every native command error",
@@ -944,6 +948,13 @@ for (const marker of [
     `release ARM64 gate must run the native Windows behavior contract ${marker}`,
   );
 }
+assert.ok(
+  releaseWorkflow.includes("- name: Verify tagged commit passed main gates") &&
+    releaseWorkflow.includes('test "$(git rev-parse origin/main)" = "$GITHUB_SHA"') &&
+    releaseWorkflow.includes("for name in validate native-x64 native-arm64") &&
+    releaseWorkflow.includes('.app.slug == "github-actions"'),
+  "tag releases must verify successful main checks for the exact tagged commit",
+);
 for (const marker of [
   "orca-windows-runner.exe",
   "orca-windows-sandbox-setup.exe",

--- a/scripts/test-validate-windows-platform-boundaries.mjs
+++ b/scripts/test-validate-windows-platform-boundaries.mjs
@@ -950,6 +950,7 @@ for (const marker of [
 }
 assert.ok(
   releaseWorkflow.includes("- name: Verify tagged commit passed main gates") &&
+    releaseWorkflow.includes("checks: read") &&
     releaseWorkflow.includes('test "$(git rev-parse origin/main)" = "$GITHUB_SHA"') &&
     releaseWorkflow.includes("for name in validate native-x64 native-arm64") &&
     releaseWorkflow.includes('.app.slug == "github-actions"'),


### PR DESCRIPTION
## What changed

- derive background provider terminal proofs from the latest authoritative surface snapshot
- include committed tool receipts when denial and provider completion race
- make tag releases verify successful `main` checks for the exact SHA instead of rerunning full suites
- retain the complete test matrix for manual release dry-runs

## Root cause

A background provider completion could construct a terminal record with an empty proof after a tool result had already become durable. The reducer correctly rejected that mismatch. Separately, tag publication repeated the complete Linux and Windows suites even though the exact commit had already passed the required `main` checks.

## Verification

- background approval denial test passed 10 consecutive times with nextest retries disabled
- `orca-tui` CI-serial suite passed 1342/1342 with retries disabled
- `cargo clippy --workspace --all-targets --locked -j 1`
- `node --test scripts/test-validate-windows-platform-boundaries.mjs`
- `node scripts/validate-windows-platform-boundaries.mjs`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Background workflow completion records now use verified operation results instead of unverified placeholders.
  * Improved handling when required operation information is unavailable during completion.

* **Release Process**
  * Tag-triggered releases now verify the tagged commit matches the current main branch and has passed required platform checks.
  * Windows platform behavior gates now run during explicitly dispatched validation runs.

* **Documentation**
  * Updated release documentation to explain CI evidence reuse and manual dry-run validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->