### PR TITLE
[codex] Release v0.4.30

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,11 +35,18 @@ jobs:
         run: |
           git fetch origin main --depth=1
           test "$(git rev-parse origin/main)" = "$GITHUB_SHA"
-          checks="$(gh api "repos/${GITHUB_REPOSITORY}/commits/${GITHUB_SHA}/check-runs")"
-          for name in validate native-x64 native-arm64; do
+          checks="$(gh api "repos/${GITHUB_REPOSITORY}/commits/${GITHUB_SHA}/check-runs?per_page=100")"
+          for name in linux-full native-x64 native-arm64; do
             jq -e --arg name "$name" \
               'any(.check_runs[]; .name == $name and .conclusion == "success" and .app.slug == "github-actions")' \
               <<<"$checks" >/dev/null
+          done
+          runs="$(gh api --method GET "repos/${GITHUB_REPOSITORY}/actions/runs" \
+            -f head_sha="$GITHUB_SHA" -f event=push -f status=completed -f per_page=100)"
+          for workflow in Linux Windows; do
+            jq -e --arg workflow "$workflow" --arg sha "$GITHUB_SHA" \
+              'any(.workflow_runs[]; .name == $workflow and .head_sha == $sha and .event == "push" and .conclusion == "success")' \
+              <<<"$runs" >/dev/null
           done
       - uses: dtolnay/rust-toolchain@stable
         if: github.event_name == 'workflow_dispatch'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -75,19 +75,19 @@ jobs:
         if: github.event_name == 'workflow_dispatch'
         env:
           RUST_BACKTRACE: "1"
-        run: cargo nextest run -p orca-tui --lib --locked --profile ci-serial
+        run: cargo nextest run -p orca-tui --lib --locked --profile ci-serial --retries 0
       - name: Run TUI PTY contract gate
         if: github.event_name == 'workflow_dispatch'
         env:
           RUST_BACKTRACE: "1"
-        run: cargo nextest run --test tui_pty_contract --locked --profile ci-serial
+        run: cargo nextest run --test tui_pty_contract --locked --profile ci-serial --retries 0
       - name: Run workspace gate
         if: github.event_name == 'workflow_dispatch'
         env:
           RUST_BACKTRACE: "1"
         run: |
           cargo clippy --workspace --all-targets --locked -j 1
-          cargo nextest run --workspace --all-targets --locked --profile ci --no-fail-fast
+          cargo nextest run --workspace --all-targets --locked --profile ci --no-fail-fast --retries 0
           cargo test -p orca-runtime --lib generation_stop_terminal_mapping_preserves_not_started_reasons --locked -- --test-threads=1
           cargo test -p orca-runtime --lib surface_goal_terminal_checkpoint_failure_recovers_exact_verified_batch --locked -- --test-threads=1
           cargo test -p orca-runtime --test runtime_host --locked -- --test-threads=1
@@ -202,9 +202,9 @@ jobs:
           cargo test -p orca-runtime --test runtime_surface_commit thread_and_policy_owner_leases_fail_closed_and_wall_rollback_has_no_authority --locked -- --nocapture
           cargo test --test history_contract history_rename_search_and_compress_work_for_latest --locked -- --nocapture
           cargo build -p orca-windows-runner --locked
-          cargo nextest run -p orca-tui --lib --locked --profile ci-serial
-          cargo nextest run --test tui_pty_contract --locked --profile ci-serial --no-tests=pass
-          cargo nextest run --workspace --all-targets --locked --profile ci --no-fail-fast
+          cargo nextest run -p orca-tui --lib --locked --profile ci-serial --retries 0
+          cargo nextest run --test tui_pty_contract --locked --profile ci-serial --no-tests=pass --retries 0
+          cargo nextest run --workspace --all-targets --locked --profile ci --no-fail-fast --retries 0
       - name: Run native Windows ARM64 behavior gates
         if: github.event_name == 'workflow_dispatch' && matrix.target == 'aarch64-pc-windows-msvc'
         shell: pwsh
@@ -225,6 +225,10 @@ jobs:
           cargo test -p orca-runtime --lib goal_runtime_lease_is_shared_in_process_and_exclusive_across_processes --locked -- --nocapture
           cargo test -p orca-runtime --test runtime_surface_commit thread_and_policy_owner_leases_fail_closed_and_wall_rollback_has_no_authority --locked -- --nocapture
           cargo test --test history_contract history_rename_search_and_compress_work_for_latest --locked -- --nocapture
+          cargo build -p orca-windows-runner --locked
+          cargo nextest run -p orca-tui --lib --locked --profile ci-serial --retries 0
+          cargo nextest run --test tui_pty_contract --locked --profile ci-serial --no-tests=pass --retries 0
+          cargo nextest run --workspace --all-targets --locked --profile ci --no-fail-fast --retries 0
       - name: Build
         run: cargo build --release --target ${{ matrix.target }} --locked
       - name: Smoke the native Windows release binary

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,7 +50,7 @@ jobs:
           done
       - uses: dtolnay/rust-toolchain@stable
         if: github.event_name == 'workflow_dispatch'
-      - uses: taiki-e/install-action@nextest
+      - uses: taiki-e/install-action@4dc1969decfa71b34f25aa7f3dd4656654d9ad1e # nextest
         if: github.event_name == 'workflow_dispatch'
       - uses: Swatinem/rust-cache@v2
         if: github.event_name == 'workflow_dispatch'
@@ -177,7 +177,7 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
         with:
           targets: ${{ matrix.target }}
-      - uses: taiki-e/install-action@nextest
+      - uses: taiki-e/install-action@4dc1969decfa71b34f25aa7f3dd4656654d9ad1e # nextest
         if: runner.os == 'Windows'
       - uses: Swatinem/rust-cache@v2
       - name: Install Linux ARM64 linker

--- a/.github/workflows/runtime-contract.yml
+++ b/.github/workflows/runtime-contract.yml
@@ -1,32 +1,44 @@
-name: Runtime Surface Contract
+name: Linux
 
 on:
   workflow_dispatch:
   pull_request:
     branches: [main]
     paths:
-      - "crates/orca-runtime/**"
-      - "crates/orca-tui/**"
+      - "Cargo.toml"
+      - "Cargo.lock"
+      - "src/**"
+      - "crates/**"
+      - "tests/**"
+      - "terminal_bench/**"
+      - "npm/orca/**"
+      - "install.sh"
+      - "install.ps1"
+      - "scripts/**"
       - "docs/superpowers/plans/2026-07-21-runtime-owned-typed-surface-implementation.md"
       - "docs/superpowers/specs/2026-07-21-runtime-owned-typed-surface-private-contract*"
-      - "scripts/validate-runtime-surface-contract.mjs"
-      - "scripts/test-validate-runtime-surface-contract.mjs"
-      - "scripts/validate-execution-broker-boundary.mjs"
-      - "scripts/test-validate-execution-broker-boundary.mjs"
+      - ".config/nextest.toml"
+      - ".gitattributes"
       - ".github/workflows/runtime-contract.yml"
       - ".github/workflows/release.yml"
       - ".github/workflows/windows-ci.yml"
   push:
     branches: [main]
     paths:
-      - "crates/orca-runtime/**"
-      - "crates/orca-tui/**"
+      - "Cargo.toml"
+      - "Cargo.lock"
+      - "src/**"
+      - "crates/**"
+      - "tests/**"
+      - "terminal_bench/**"
+      - "npm/orca/**"
+      - "install.sh"
+      - "install.ps1"
+      - "scripts/**"
       - "docs/superpowers/plans/2026-07-21-runtime-owned-typed-surface-implementation.md"
       - "docs/superpowers/specs/2026-07-21-runtime-owned-typed-surface-private-contract*"
-      - "scripts/validate-runtime-surface-contract.mjs"
-      - "scripts/test-validate-runtime-surface-contract.mjs"
-      - "scripts/validate-execution-broker-boundary.mjs"
-      - "scripts/test-validate-execution-broker-boundary.mjs"
+      - ".config/nextest.toml"
+      - ".gitattributes"
       - ".github/workflows/runtime-contract.yml"
       - ".github/workflows/release.yml"
       - ".github/workflows/windows-ci.yml"
@@ -35,8 +47,9 @@ permissions:
   contents: read
 
 jobs:
-  validate:
-    runs-on: ubuntu-latest
+  linux-full:
+    runs-on: ubuntu-22.04
+    timeout-minutes: 90
     steps:
       - uses: actions/checkout@v5
         with:
@@ -46,7 +59,12 @@ jobs:
         with:
           node-version: 22
       - uses: dtolnay/rust-toolchain@stable
+      - uses: taiki-e/install-action@nextest
       - uses: Swatinem/rust-cache@v2
+      - name: Install test runtime dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y ripgrep bubblewrap
       - name: Validate reviewed artifacts and current inventories
         run: |
           node scripts/test-validate-runtime-surface-contract.mjs
@@ -57,3 +75,27 @@ jobs:
         run: |
           cargo metadata --locked --format-version 1 > /dev/null
           cargo test -p orca-tui runtime_surface_contract --lib --locked
+      - name: Validate repository adapters and hygiene
+        run: |
+          python3 -m unittest discover -s terminal_bench -p 'test_*.py' -v
+          node scripts/test-repository-hygiene.mjs
+      - name: Run TUI library gate
+        env:
+          RUST_BACKTRACE: "1"
+        run: cargo nextest run -p orca-tui --lib --locked --profile ci-serial
+      - name: Run TUI PTY contract gate
+        env:
+          RUST_BACKTRACE: "1"
+        run: cargo nextest run --test tui_pty_contract --locked --profile ci-serial
+      - name: Run workspace gate
+        env:
+          RUST_BACKTRACE: "1"
+        run: |
+          cargo clippy --workspace --all-targets --locked -j 1
+          cargo nextest run --workspace --all-targets --locked --profile ci --no-fail-fast
+          cargo test -p orca-runtime --lib generation_stop_terminal_mapping_preserves_not_started_reasons --locked -- --test-threads=1
+          cargo test -p orca-runtime --lib surface_goal_terminal_checkpoint_failure_recovers_exact_verified_batch --locked -- --test-threads=1
+          cargo test -p orca-runtime --test runtime_host --locked -- --test-threads=1
+          cargo test -p orca-runtime --test subagent_observability_contract --locked -- --test-threads=1
+          cargo test -p orca-runtime --test runtime_surface_interaction --locked -- --test-threads=1
+          cargo test --test subagent_contract --locked -- --test-threads=1

--- a/.github/workflows/runtime-contract.yml
+++ b/.github/workflows/runtime-contract.yml
@@ -82,17 +82,17 @@ jobs:
       - name: Run TUI library gate
         env:
           RUST_BACKTRACE: "1"
-        run: cargo nextest run -p orca-tui --lib --locked --profile ci-serial
+        run: cargo nextest run -p orca-tui --lib --locked --profile ci-serial --retries 0
       - name: Run TUI PTY contract gate
         env:
           RUST_BACKTRACE: "1"
-        run: cargo nextest run --test tui_pty_contract --locked --profile ci-serial
+        run: cargo nextest run --test tui_pty_contract --locked --profile ci-serial --retries 0
       - name: Run workspace gate
         env:
           RUST_BACKTRACE: "1"
         run: |
           cargo clippy --workspace --all-targets --locked -j 1
-          cargo nextest run --workspace --all-targets --locked --profile ci --no-fail-fast
+          cargo nextest run --workspace --all-targets --locked --profile ci --no-fail-fast --retries 0
           cargo test -p orca-runtime --lib generation_stop_terminal_mapping_preserves_not_started_reasons --locked -- --test-threads=1
           cargo test -p orca-runtime --lib surface_goal_terminal_checkpoint_failure_recovers_exact_verified_batch --locked -- --test-threads=1
           cargo test -p orca-runtime --test runtime_host --locked -- --test-threads=1

--- a/.github/workflows/runtime-contract.yml
+++ b/.github/workflows/runtime-contract.yml
@@ -59,7 +59,7 @@ jobs:
         with:
           node-version: 22
       - uses: dtolnay/rust-toolchain@stable
-      - uses: taiki-e/install-action@nextest
+      - uses: taiki-e/install-action@4dc1969decfa71b34f25aa7f3dd4656654d9ad1e # nextest
       - uses: Swatinem/rust-cache@v2
       - name: Install test runtime dependencies
         run: |

--- a/.github/workflows/windows-ci.yml
+++ b/.github/workflows/windows-ci.yml
@@ -62,7 +62,7 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
       - uses: dtolnay/rust-toolchain@stable
-      - uses: taiki-e/install-action@nextest
+      - uses: taiki-e/install-action@4dc1969decfa71b34f25aa7f3dd4656654d9ad1e # nextest
       - uses: Swatinem/rust-cache@v2
         with:
           prefix-key: windows-x64-${{ hashFiles('Cargo.lock') }}
@@ -132,7 +132,7 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
         with:
           targets: aarch64-pc-windows-msvc
-      - uses: taiki-e/install-action@nextest
+      - uses: taiki-e/install-action@4dc1969decfa71b34f25aa7f3dd4656654d9ad1e # nextest
       - uses: Swatinem/rust-cache@v2
         with:
           prefix-key: windows-arm64-${{ hashFiles('Cargo.lock') }}

--- a/.github/workflows/windows-ci.yml
+++ b/.github/workflows/windows-ci.yml
@@ -115,9 +115,9 @@ jobs:
         run: |
           $ErrorActionPreference = "Stop"
           $PSNativeCommandUseErrorActionPreference = $true
-          cargo nextest run -p orca-tui --lib --locked --profile ci-serial
-          cargo nextest run --test tui_pty_contract --locked --profile ci-serial --no-tests=pass
-          cargo nextest run --workspace --all-targets --locked --profile ci --no-fail-fast
+          cargo nextest run -p orca-tui --lib --locked --profile ci-serial --retries 0
+          cargo nextest run --test tui_pty_contract --locked --profile ci-serial --no-tests=pass --retries 0
+          cargo nextest run --workspace --all-targets --locked --profile ci --no-fail-fast --retries 0
 
   native-arm64:
     runs-on: windows-11-arm
@@ -184,6 +184,6 @@ jobs:
         run: |
           $ErrorActionPreference = "Stop"
           $PSNativeCommandUseErrorActionPreference = $true
-          cargo nextest run -p orca-tui --lib --locked --profile ci-serial
-          cargo nextest run --test tui_pty_contract --locked --profile ci-serial --no-tests=pass
-          cargo nextest run --workspace --all-targets --locked --profile ci --no-fail-fast
+          cargo nextest run -p orca-tui --lib --locked --profile ci-serial --retries 0
+          cargo nextest run --test tui_pty_contract --locked --profile ci-serial --no-tests=pass --retries 0
+          cargo nextest run --workspace --all-targets --locked --profile ci --no-fail-fast --retries 0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -235,7 +235,7 @@ checksum = "84d7ced0ae9557296835c32bf1b1e02b44c746701f898460fb000d7eaa84f00a"
 
 [[package]]
 name = "blade-deepseek"
-version = "0.4.29"
+version = "0.4.30"
 dependencies = [
  "base64",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,7 +55,7 @@ arboard = { version = "3", features = ["wayland-data-control"] }
 
 [package]
 name = "blade-deepseek"
-version = "0.4.29"
+version = "0.4.30"
 edition = "2024"
 description = "Orca: a DeepSeek-native coding agent"
 license = "MIT"

--- a/crates/orca-platform/src/fs/atomic.rs
+++ b/crates/orca-platform/src/fs/atomic.rs
@@ -240,7 +240,7 @@ mod platform {
 
     use windows_sys::Win32::Foundation::{
         ERROR_FILE_NOT_FOUND, ERROR_LOCK_VIOLATION, ERROR_SHARING_VIOLATION,
-        ERROR_UNABLE_TO_REMOVE_REPLACED,
+        ERROR_UNABLE_TO_MOVE_REPLACEMENT, ERROR_UNABLE_TO_REMOVE_REPLACED,
     };
     use windows_sys::Win32::Storage::FileSystem::{
         FILE_SHARE_DELETE, FILE_SHARE_READ, FILE_SHARE_WRITE, FlushFileBuffers,
@@ -319,6 +319,7 @@ mod platform {
                     if code == ERROR_SHARING_VIOLATION as i32
                         || code == ERROR_LOCK_VIOLATION as i32
                         || code == ERROR_UNABLE_TO_REMOVE_REPLACED as i32
+                        || code == ERROR_UNABLE_TO_MOVE_REPLACEMENT as i32
                         || (destination_existed && code == ERROR_FILE_NOT_FOUND as i32)
             ) || Instant::now() >= deadline
             {

--- a/crates/orca-platform/src/fs/atomic.rs
+++ b/crates/orca-platform/src/fs/atomic.rs
@@ -238,7 +238,9 @@ mod platform {
     use std::os::windows::fs::OpenOptionsExt;
     use std::os::windows::io::AsRawHandle;
 
-    use windows_sys::Win32::Foundation::{ERROR_LOCK_VIOLATION, ERROR_SHARING_VIOLATION};
+    use windows_sys::Win32::Foundation::{
+        ERROR_LOCK_VIOLATION, ERROR_SHARING_VIOLATION, ERROR_UNABLE_TO_REMOVE_REPLACED,
+    };
     use windows_sys::Win32::Storage::FileSystem::{
         FILE_SHARE_DELETE, FILE_SHARE_READ, FILE_SHARE_WRITE, FlushFileBuffers,
         MOVEFILE_WRITE_THROUGH, MoveFileExW, REPLACEFILE_WRITE_THROUGH, ReplaceFileW,
@@ -315,6 +317,7 @@ mod platform {
                 Some(code)
                     if code == ERROR_SHARING_VIOLATION as i32
                         || code == ERROR_LOCK_VIOLATION as i32
+                        || code == ERROR_UNABLE_TO_REMOVE_REPLACED as i32
             ) || Instant::now() >= deadline
             {
                 return Err(PlatformError::io("atomically replace destination", error));

--- a/crates/orca-platform/src/fs/atomic.rs
+++ b/crates/orca-platform/src/fs/atomic.rs
@@ -313,15 +313,10 @@ mod platform {
                 return Ok(());
             }
             let error = io::Error::last_os_error();
-            if !matches!(
-                error.raw_os_error(),
-                Some(code)
-                    if code == ERROR_SHARING_VIOLATION as i32
-                        || code == ERROR_LOCK_VIOLATION as i32
-                        || code == ERROR_UNABLE_TO_REMOVE_REPLACED as i32
-                        || code == ERROR_UNABLE_TO_MOVE_REPLACEMENT as i32
-                        || (destination_existed && code == ERROR_FILE_NOT_FOUND as i32)
-            ) || Instant::now() >= deadline
+            if !error
+                .raw_os_error()
+                .is_some_and(|code| retryable_replace_error(code, destination_existed))
+                || Instant::now() >= deadline
             {
                 return Err(PlatformError::io("atomically replace destination", error));
             }
@@ -335,5 +330,33 @@ mod platform {
 
     fn wide_path(path: &Path) -> Vec<u16> {
         path.as_os_str().encode_wide().chain(Some(0)).collect()
+    }
+
+    fn retryable_replace_error(code: i32, destination_existed: bool) -> bool {
+        code == ERROR_SHARING_VIOLATION as i32
+            || code == ERROR_LOCK_VIOLATION as i32
+            || code == ERROR_UNABLE_TO_REMOVE_REPLACED as i32
+            || code == ERROR_UNABLE_TO_MOVE_REPLACEMENT as i32
+            || (destination_existed && code == ERROR_FILE_NOT_FOUND as i32)
+    }
+
+    #[cfg(test)]
+    mod tests {
+        use super::*;
+
+        #[test]
+        fn retryable_replace_errors_cover_safe_windows_collision_states() {
+            for code in [
+                ERROR_SHARING_VIOLATION,
+                ERROR_LOCK_VIOLATION,
+                ERROR_UNABLE_TO_REMOVE_REPLACED,
+                ERROR_UNABLE_TO_MOVE_REPLACEMENT,
+            ] {
+                assert!(retryable_replace_error(code as i32, false));
+            }
+            assert!(retryable_replace_error(ERROR_FILE_NOT_FOUND as i32, true));
+            assert!(!retryable_replace_error(ERROR_FILE_NOT_FOUND as i32, false));
+            assert!(!retryable_replace_error(1177, true));
+        }
     }
 }

--- a/crates/orca-platform/src/fs/atomic.rs
+++ b/crates/orca-platform/src/fs/atomic.rs
@@ -239,7 +239,8 @@ mod platform {
     use std::os::windows::io::AsRawHandle;
 
     use windows_sys::Win32::Foundation::{
-        ERROR_LOCK_VIOLATION, ERROR_SHARING_VIOLATION, ERROR_UNABLE_TO_REMOVE_REPLACED,
+        ERROR_FILE_NOT_FOUND, ERROR_LOCK_VIOLATION, ERROR_SHARING_VIOLATION,
+        ERROR_UNABLE_TO_REMOVE_REPLACED,
     };
     use windows_sys::Win32::Storage::FileSystem::{
         FILE_SHARE_DELETE, FILE_SHARE_READ, FILE_SHARE_WRITE, FlushFileBuffers,
@@ -318,6 +319,7 @@ mod platform {
                     if code == ERROR_SHARING_VIOLATION as i32
                         || code == ERROR_LOCK_VIOLATION as i32
                         || code == ERROR_UNABLE_TO_REMOVE_REPLACED as i32
+                        || (destination_existed && code == ERROR_FILE_NOT_FOUND as i32)
             ) || Instant::now() >= deadline
             {
                 return Err(PlatformError::io("atomically replace destination", error));

--- a/crates/orca-platform/tests/atomic_file_contract.rs
+++ b/crates/orca-platform/tests/atomic_file_contract.rs
@@ -1,9 +1,9 @@
 use std::io::{self, Write};
 use std::path::Path;
 
-use orca_platform::fs::{
-    AtomicWritePolicy, atomic_write, atomic_write_with, open_nofollow, open_nofollow_nonblocking,
-};
+#[cfg(unix)]
+use orca_platform::fs::open_nofollow_nonblocking;
+use orca_platform::fs::{AtomicWritePolicy, atomic_write, atomic_write_with, open_nofollow};
 
 #[test]
 fn atomic_replace_never_leaves_a_partial_file_or_temp_artifact() {
@@ -237,6 +237,98 @@ fn concurrent_atomic_writers_complete_and_leave_a_readable_destination() {
         !std::fs::read_to_string(&path)
             .expect("final atomic destination")
             .is_empty()
+    );
+    assert_no_temp_artifacts(temp.path());
+}
+
+#[cfg(windows)]
+#[test]
+fn cross_process_atomic_writer_child() {
+    let Some(destination) = std::env::var_os("ORCA_ATOMIC_WRITE_CHILD_DESTINATION") else {
+        return;
+    };
+    let start =
+        std::env::var_os("ORCA_ATOMIC_WRITE_CHILD_START").expect("cross-process writer start path");
+    let ready =
+        std::env::var_os("ORCA_ATOMIC_WRITE_CHILD_READY").expect("cross-process writer ready path");
+    let writer = std::env::var("ORCA_ATOMIC_WRITE_CHILD_ID").expect("cross-process writer id");
+
+    std::fs::write(&ready, b"ready").expect("announce cross-process writer");
+    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(10);
+    while !Path::new(&start).exists() {
+        assert!(
+            std::time::Instant::now() < deadline,
+            "cross-process writer start signal timed out"
+        );
+        std::thread::sleep(std::time::Duration::from_millis(5));
+    }
+
+    let destination = Path::new(&destination);
+    for revision in 0..128 {
+        let value = format!("writer-{writer}-revision-{revision}");
+        atomic_write(destination, value.as_bytes(), AtomicWritePolicy::NoFollow)
+            .expect("cross-process atomic write");
+    }
+}
+
+#[cfg(windows)]
+#[test]
+fn concurrent_cross_process_atomic_writers_retry_replace_collisions() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let destination = temp.path().join("state.json");
+    let start = temp.path().join("start");
+    atomic_write(&destination, b"seed", AtomicWritePolicy::NoFollow).expect("seed state");
+
+    let executable = std::env::current_exe().expect("current test executable");
+    let mut children = Vec::new();
+    let mut ready_paths = Vec::new();
+    for writer in 0..4 {
+        let ready = temp.path().join(format!("writer-{writer}.ready"));
+        let child = std::process::Command::new(&executable)
+            .args([
+                "--exact",
+                "cross_process_atomic_writer_child",
+                "--test-threads=1",
+                "--nocapture",
+            ])
+            .env("ORCA_ATOMIC_WRITE_CHILD_DESTINATION", &destination)
+            .env("ORCA_ATOMIC_WRITE_CHILD_START", &start)
+            .env("ORCA_ATOMIC_WRITE_CHILD_READY", &ready)
+            .env("ORCA_ATOMIC_WRITE_CHILD_ID", writer.to_string())
+            .stdout(std::process::Stdio::piped())
+            .stderr(std::process::Stdio::piped())
+            .spawn()
+            .expect("launch cross-process atomic writer");
+        children.push(child);
+        ready_paths.push(ready);
+    }
+
+    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(10);
+    while ready_paths.iter().any(|ready| !ready.exists()) {
+        assert!(
+            std::time::Instant::now() < deadline,
+            "cross-process writers did not become ready"
+        );
+        std::thread::sleep(std::time::Duration::from_millis(5));
+    }
+    std::fs::write(&start, b"go").expect("release cross-process writers");
+
+    for child in children {
+        let child = child
+            .wait_with_output()
+            .expect("wait for cross-process atomic writer");
+        assert!(
+            child.status.success(),
+            "cross-process atomic writer failed: status={:?}, stdout={}, stderr={}",
+            child.status,
+            String::from_utf8_lossy(&child.stdout),
+            String::from_utf8_lossy(&child.stderr)
+        );
+    }
+    assert!(
+        std::fs::read_to_string(&destination)
+            .expect("final atomic destination")
+            .starts_with("writer-")
     );
     assert_no_temp_artifacts(temp.path());
 }

--- a/crates/orca-platform/tests/atomic_file_contract.rs
+++ b/crates/orca-platform/tests/atomic_file_contract.rs
@@ -305,18 +305,28 @@ fn concurrent_cross_process_atomic_writers_retry_replace_collisions() {
 
     let deadline = std::time::Instant::now() + std::time::Duration::from_secs(10);
     while ready_paths.iter().any(|ready| !ready.exists()) {
-        assert!(
-            std::time::Instant::now() < deadline,
-            "cross-process writers did not become ready"
-        );
+        if std::time::Instant::now() >= deadline {
+            for child in &mut children {
+                let _ = child.kill();
+            }
+            for mut child in children {
+                let _ = child.wait();
+            }
+            panic!("cross-process writers did not become ready");
+        }
         std::thread::sleep(std::time::Duration::from_millis(5));
     }
     std::fs::write(&start, b"go").expect("release cross-process writers");
 
-    for child in children {
-        let child = child
-            .wait_with_output()
-            .expect("wait for cross-process atomic writer");
+    let outputs = children
+        .into_iter()
+        .map(|child| {
+            child
+                .wait_with_output()
+                .expect("wait for cross-process atomic writer")
+        })
+        .collect::<Vec<_>>();
+    for child in outputs {
         assert!(
             child.status.success(),
             "cross-process atomic writer failed: status={:?}, stdout={}, stderr={}",

--- a/crates/orca-platform/tests/atomic_file_contract.rs
+++ b/crates/orca-platform/tests/atomic_file_contract.rs
@@ -1,6 +1,8 @@
 use std::io::{self, Write};
 use std::path::Path;
 
+#[cfg(windows)]
+use orca_platform::fs::ExclusiveFileLock;
 #[cfg(unix)]
 use orca_platform::fs::open_nofollow_nonblocking;
 use orca_platform::fs::{AtomicWritePolicy, atomic_write, atomic_write_with, open_nofollow};
@@ -249,6 +251,8 @@ fn cross_process_atomic_writer_child() {
     };
     let start =
         std::env::var_os("ORCA_ATOMIC_WRITE_CHILD_START").expect("cross-process writer start path");
+    let lock =
+        std::env::var_os("ORCA_ATOMIC_WRITE_CHILD_LOCK").expect("cross-process writer lock path");
     let ready =
         std::env::var_os("ORCA_ATOMIC_WRITE_CHILD_READY").expect("cross-process writer ready path");
     let writer = std::env::var("ORCA_ATOMIC_WRITE_CHILD_ID").expect("cross-process writer id");
@@ -266,6 +270,8 @@ fn cross_process_atomic_writer_child() {
     let destination = Path::new(&destination);
     for revision in 0..128 {
         let value = format!("writer-{writer}-revision-{revision}");
+        let _guard = ExclusiveFileLock::acquire(Path::new(&lock))
+            .expect("acquire cross-process atomic write lock");
         atomic_write(destination, value.as_bytes(), AtomicWritePolicy::NoFollow)
             .expect("cross-process atomic write");
     }
@@ -273,9 +279,10 @@ fn cross_process_atomic_writer_child() {
 
 #[cfg(windows)]
 #[test]
-fn concurrent_cross_process_atomic_writers_retry_replace_collisions() {
+fn concurrent_cross_process_atomic_writers_are_serialized() {
     let temp = tempfile::tempdir().expect("tempdir");
     let destination = temp.path().join("state.json");
+    let lock = temp.path().join("state.lock");
     let start = temp.path().join("start");
     atomic_write(&destination, b"seed", AtomicWritePolicy::NoFollow).expect("seed state");
 
@@ -293,6 +300,7 @@ fn concurrent_cross_process_atomic_writers_retry_replace_collisions() {
             ])
             .env("ORCA_ATOMIC_WRITE_CHILD_DESTINATION", &destination)
             .env("ORCA_ATOMIC_WRITE_CHILD_START", &start)
+            .env("ORCA_ATOMIC_WRITE_CHILD_LOCK", &lock)
             .env("ORCA_ATOMIC_WRITE_CHILD_READY", &ready)
             .env("ORCA_ATOMIC_WRITE_CHILD_ID", writer.to_string())
             .stdout(std::process::Stdio::piped())

--- a/crates/orca-runtime/src/runtime_host.rs
+++ b/crates/orca-runtime/src/runtime_host.rs
@@ -17376,7 +17376,6 @@ impl ThreadActor {
                                     "goal run paused during runtime shutdown",
                                 );
                                 if pause_result.is_ok() && self.goal_controller.is_blocking() {
-                                    active.generation.cancel.cancel();
                                     if let Some(reply) = reply {
                                         let _ = reply.send(ThreadShutdownAck::Retry);
                                     }
@@ -17451,7 +17450,6 @@ impl ThreadActor {
                                 "goal run paused during runtime shutdown",
                             );
                             if pause_result.is_ok() && self.goal_controller.is_blocking() {
-                                active.generation.cancel.cancel();
                                 if let Some(reply) = reply {
                                     let _ = reply.send(ThreadShutdownAck::Retry);
                                 }

--- a/crates/orca-runtime/src/runtime_host.rs
+++ b/crates/orca-runtime/src/runtime_host.rs
@@ -37006,14 +37006,23 @@ mod tests {
                 .expect("submit prepared Goal continuation"),
         );
         let operation_id = output.operation_id.expect("Goal operation id");
-        let deadline = Instant::now() + SURFACE_TEST_TIMEOUT;
-        let prepared = loop {
-            let recovered =
-                surface::JsonlSurfaceCommitLedger::new(&transcript_path, initial_cursor.clone())
-                    .recover_batches()
-                    .expect("read prepared Goal continuation");
-            if let Some(batch) = recovered.prepared
-                && batch.events.as_slice().iter().any(|event| {
+        let checkpoint_observed =
+            surface::JsonlSurfaceCommitLedger::wait_for_terminal_checkpoint_failure(
+                transcript_path.clone(),
+                Duration::from_secs(15),
+            );
+        assert!(
+            checkpoint_observed,
+            "Goal continuation did not reach the injected checkpoint failure"
+        );
+        let recovered =
+            surface::JsonlSurfaceCommitLedger::new(&transcript_path, initial_cursor.clone())
+                .recover_batches()
+                .expect("read prepared Goal continuation");
+        let prepared = recovered
+            .prepared
+            .filter(|batch| {
+                batch.events.as_slice().iter().any(|event| {
                     matches!(
                         &event.event,
                         surface::SurfaceEvent::Goal(surface::GoalPatchEnvelope {
@@ -37025,15 +37034,8 @@ mod tests {
                         })
                     )
                 })
-            {
-                break batch;
-            }
-            assert!(
-                Instant::now() < deadline,
-                "Goal continuation did not reach prepared state"
-            );
-            std::thread::yield_now();
-        };
+            })
+            .expect("injected checkpoint failure must retain the prepared Goal continuation");
         assert_eq!(executor.calls.load(Ordering::SeqCst), 1);
         let prepared_commit = prepared.commit_class.clone();
         let prepared_digest = prepared.batch_digest.clone();

--- a/crates/orca-runtime/src/runtime_surface/store.rs
+++ b/crates/orca-runtime/src/runtime_surface/store.rs
@@ -62,7 +62,7 @@ use std::collections::{HashMap, HashSet};
 use std::fs::File;
 use std::io::Read;
 use std::path::{Path, PathBuf};
-use std::sync::{Mutex, OnceLock};
+use std::sync::{Condvar, Mutex, OnceLock};
 
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub enum SurfaceLedgerError {
@@ -3108,6 +3108,9 @@ static TERMINAL_CHECKPOINT_FAILURES: OnceLock<Mutex<HashMap<PathBuf, usize>>> = 
 static PENDING_TERMINAL_CHECKPOINT_FAILURES: OnceLock<Mutex<HashMap<PathBuf, usize>>> =
     OnceLock::new();
 #[cfg(test)]
+static OBSERVED_TERMINAL_CHECKPOINT_FAILURES: OnceLock<(Mutex<HashSet<PathBuf>>, Condvar)> =
+    OnceLock::new();
+#[cfg(test)]
 static ADMISSION_CHECKPOINT_FAILURES: OnceLock<Mutex<HashMap<PathBuf, usize>>> = OnceLock::new();
 #[cfg(test)]
 static PENDING_ADMISSION_CHECKPOINT_FAILURES: OnceLock<Mutex<HashMap<PathBuf, usize>>> =
@@ -3407,6 +3410,29 @@ impl JsonlSurfaceCommitLedger {
             .lock()
             .unwrap_or_else(|poisoned| poisoned.into_inner())
             .remove(&path);
+        OBSERVED_TERMINAL_CHECKPOINT_FAILURES
+            .get_or_init(|| (Mutex::new(HashSet::new()), Condvar::new()))
+            .0
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .remove(&path);
+    }
+
+    #[cfg(test)]
+    pub(crate) fn wait_for_terminal_checkpoint_failure(
+        path: impl Into<PathBuf>,
+        timeout: std::time::Duration,
+    ) -> bool {
+        let path = path.into();
+        let (observed, changed) = OBSERVED_TERMINAL_CHECKPOINT_FAILURES
+            .get_or_init(|| (Mutex::new(HashSet::new()), Condvar::new()));
+        let observed = observed
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        let (mut observed, _) = changed
+            .wait_timeout_while(observed, timeout, |observed| !observed.contains(&path))
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        observed.remove(&path)
     }
 
     #[cfg(test)]
@@ -3845,19 +3871,31 @@ impl JsonlSurfaceCommitLedger {
 
     #[cfg(test)]
     fn take_pending_terminal_checkpoint_failure(&self) -> bool {
-        let mut failures = PENDING_TERMINAL_CHECKPOINT_FAILURES
-            .get_or_init(|| Mutex::new(HashMap::new()))
-            .lock()
-            .unwrap_or_else(|poisoned| poisoned.into_inner());
-        let Some(count) = failures.get_mut(&self.path) else {
-            return false;
+        let should_fail = {
+            let mut failures = PENDING_TERMINAL_CHECKPOINT_FAILURES
+                .get_or_init(|| Mutex::new(HashMap::new()))
+                .lock()
+                .unwrap_or_else(|poisoned| poisoned.into_inner());
+            let Some(count) = failures.get_mut(&self.path) else {
+                return false;
+            };
+            if *count <= 1 {
+                failures.remove(&self.path);
+            } else {
+                *count -= 1;
+            }
+            true
         };
-        if *count <= 1 {
-            failures.remove(&self.path);
-        } else {
-            *count -= 1;
+        if should_fail {
+            let (observed, changed) = OBSERVED_TERMINAL_CHECKPOINT_FAILURES
+                .get_or_init(|| (Mutex::new(HashSet::new()), Condvar::new()));
+            observed
+                .lock()
+                .unwrap_or_else(|poisoned| poisoned.into_inner())
+                .insert(self.path.clone());
+            changed.notify_all();
         }
-        true
+        should_fail
     }
 
     #[cfg(test)]

--- a/crates/orca-runtime/src/workflow/state.rs
+++ b/crates/orca-runtime/src/workflow/state.rs
@@ -12,7 +12,7 @@ use orca_core::workflow_types::{
     WorkflowEvidencePhase, WorkflowEvidenceToolEvent, WorkflowInput, WorkflowRunState,
     WorkflowRunStatus, WorkflowTaskLifecycleEvidence,
 };
-use orca_platform::fs::{AtomicWritePolicy, atomic_write};
+use orca_platform::fs::{AtomicWritePolicy, ExclusiveFileLock, atomic_write};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use sha2::{Digest, Sha256};
@@ -180,6 +180,7 @@ impl Serialize for AgentOutputField {
 pub struct WorkflowStateStore {
     root: PathBuf,
     agent_cache_write_lock: Arc<Mutex<()>>,
+    run_mutation_lock: Arc<Mutex<()>>,
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -215,6 +216,7 @@ impl WorkflowStateStore {
         Self {
             root,
             agent_cache_write_lock: Arc::new(Mutex::new(())),
+            run_mutation_lock: Arc::new(Mutex::new(())),
         }
     }
 
@@ -228,6 +230,10 @@ impl WorkflowStateStore {
 
     pub fn state_path(&self, run_id: &str) -> PathBuf {
         self.run_dir(run_id).join("state.json")
+    }
+
+    fn run_mutation_lock_path(&self, run_id: &str) -> PathBuf {
+        self.run_dir(run_id).join("run-state.lock")
     }
 
     pub fn launch_input_path(&self, run_id: &str) -> PathBuf {
@@ -264,6 +270,10 @@ impl WorkflowStateStore {
     }
 
     pub fn write_state(&self, state: &WorkflowRunState) -> io::Result<()> {
+        self.with_run_mutation_lock(&state.run_id, || self.write_state_unlocked(state))
+    }
+
+    fn write_state_unlocked(&self, state: &WorkflowRunState) -> io::Result<()> {
         let run_dir = self.run_dir(&state.run_id);
         fs::create_dir_all(&run_dir)?;
         write_json_pretty(&self.state_path(&state.run_id), state)
@@ -398,10 +408,12 @@ impl WorkflowStateStore {
     }
 
     pub fn request_stop(&self, run_id: &str) -> io::Result<()> {
-        let mut control = self.load_control_request(run_id)?;
-        control.stop_requested = true;
-        control.updated_at_ms = now_ms();
-        write_json_pretty(&self.stop_request_path(run_id), &control)
+        self.with_run_mutation_lock(run_id, || {
+            let mut control = self.load_control_request(run_id)?;
+            control.stop_requested = true;
+            control.updated_at_ms = now_ms();
+            write_json_pretty(&self.stop_request_path(run_id), &control)
+        })
     }
 
     pub fn stop_requested(&self, run_id: &str) -> io::Result<bool> {
@@ -409,23 +421,27 @@ impl WorkflowStateStore {
     }
 
     pub fn request_pause(&self, run_id: &str) -> io::Result<()> {
-        let mut control = self.load_control_request(run_id)?;
-        control.pause_requested = true;
-        control.updated_at_ms = now_ms();
-        write_json_pretty(&self.stop_request_path(run_id), &control)
+        self.with_run_mutation_lock(run_id, || {
+            let mut control = self.load_control_request(run_id)?;
+            control.pause_requested = true;
+            control.updated_at_ms = now_ms();
+            write_json_pretty(&self.stop_request_path(run_id), &control)
+        })
     }
 
     pub fn request_resume(&self, run_id: &str) -> io::Result<()> {
-        let mut control = self.load_control_request(run_id)?;
-        control.pause_requested = false;
-        control.updated_at_ms = now_ms();
-        write_json_pretty(&self.stop_request_path(run_id), &control)?;
-        let mut state = self.load_run(run_id)?;
-        if state.status == WorkflowRunStatus::Paused {
-            state.status = WorkflowRunStatus::Running;
-            self.write_state(&state)?;
-        }
-        Ok(())
+        self.with_run_mutation_lock(run_id, || {
+            let mut control = self.load_control_request(run_id)?;
+            control.pause_requested = false;
+            control.updated_at_ms = now_ms();
+            write_json_pretty(&self.stop_request_path(run_id), &control)?;
+            let mut state = self.load_run(run_id)?;
+            if state.status == WorkflowRunStatus::Paused {
+                state.status = WorkflowRunStatus::Running;
+                self.write_state_unlocked(&state)?;
+            }
+            Ok(())
+        })
     }
 
     pub fn pause_requested(&self, run_id: &str) -> io::Result<bool> {
@@ -438,6 +454,20 @@ impl WorkflowStateStore {
             return Ok(WorkflowControlRequest::default());
         }
         read_json(&path)
+    }
+
+    fn with_run_mutation_lock<T>(
+        &self,
+        run_id: &str,
+        operation: impl FnOnce() -> io::Result<T>,
+    ) -> io::Result<T> {
+        let _process_guard = self
+            .run_mutation_lock
+            .lock()
+            .map_err(|_| io::Error::other("workflow run mutation lock poisoned"))?;
+        let _file_guard = ExclusiveFileLock::acquire(&self.run_mutation_lock_path(run_id))
+            .map_err(io::Error::other)?;
+        operation()
     }
 
     pub fn record_agent_completed(

--- a/crates/orca-tui/src/app_integration_tests.rs
+++ b/crates/orca-tui/src/app_integration_tests.rs
@@ -3735,12 +3735,20 @@ fn hosted_tui_rename_restores_runtime_projection_when_durable_write_fails() {
 
 #[test]
 fn hosted_tui_new_session_rejects_active_background_work() {
-    with_orca_home(|_| {
+    with_orca_home(|home| {
         let mut harness = HostedTuiHarness::start(test_config(HistoryMode::Record), None);
-        harness.send(UserAction::Submit("mock_stream_delay_ms 3000".to_string()));
-        harness.recv_until(|event| {
-                matches!(event, TuiEvent::MessageDelta(text) if text.contains("Mock slow stream started."))
-            });
+        let release_marker = home.join("release-new-session-background-work");
+        harness.send(UserAction::Submit(format!(
+            "mock_stream_release_marker {}",
+            release_marker.display()
+        )));
+        assert!(
+            harness
+                .runtime
+                .controller()
+                .wait_for_surface_active(Duration::from_secs(10)),
+            "backgrounded turn must install the TUI controller"
+        );
 
         harness.send(UserAction::BackgroundCurrentTurn);
         let task = loop {

--- a/crates/orca-tui/src/operation_controller.rs
+++ b/crates/orca-tui/src/operation_controller.rs
@@ -1160,6 +1160,19 @@ impl TuiSurfaceTaskControl {
         hosted.surface_active.is_some()
     }
 
+    #[cfg(test)]
+    pub(crate) fn wait_for_surface_inactive(&self, timeout: Duration) -> bool {
+        let hosted = self.lock_hosted();
+        let (hosted, _) = self
+            .hosted
+            .changed
+            .wait_timeout_while(hosted, timeout, |hosted| {
+                hosted.surface_active.is_some() && !hosted.shutdown
+            })
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        hosted.surface_active.is_none()
+    }
+
     pub(crate) fn install_focused_child_surface(
         &self,
         client: orca_runtime::surface::RuntimeSurfaceClientHandle,

--- a/crates/orca-tui/src/surface_client.rs
+++ b/crates/orca-tui/src/surface_client.rs
@@ -2865,10 +2865,18 @@ mod tests {
     use super::*;
 
     const TEST_SURFACE_ACTIVATION_TIMEOUT: Duration = Duration::from_secs(10);
+    const TEST_SURFACE_TERMINAL_TIMEOUT: Duration = Duration::from_secs(10);
 
     fn assert_surface_active(controller: &TuiSurfaceTaskControl, context: &str) {
         assert!(
             controller.wait_for_surface_active(TEST_SURFACE_ACTIVATION_TIMEOUT),
+            "{context}"
+        );
+    }
+
+    fn assert_surface_inactive(controller: &TuiSurfaceTaskControl, context: &str) {
+        assert!(
+            controller.wait_for_surface_inactive(TEST_SURFACE_TERMINAL_TIMEOUT),
             "{context}"
         );
     }
@@ -3403,11 +3411,15 @@ mod tests {
         );
 
         let _ = controller.interrupt_current();
+        assert_surface_inactive(
+            &controller,
+            "typed cancellation must reach a terminal controller state",
+        );
+        worker.join().expect("typed TUI worker");
         let outcome = result_rx
-            .recv_timeout(Duration::from_secs(2))
+            .recv()
             .expect("typed cancellation terminal")
             .expect("typed cancellation outcome");
-        worker.join().expect("typed TUI worker");
 
         assert!(matches!(
             outcome,
@@ -4749,11 +4761,15 @@ mod tests {
         );
         let _ = controller.interrupt_current();
 
+        assert_surface_inactive(
+            &controller,
+            "typed cancellation restart must reach a terminal controller state",
+        );
+        worker.join().expect("cancelled worker");
         let cancelled = result_rx
-            .recv_timeout(Duration::from_secs(2))
+            .recv()
             .expect("cancelled terminal")
             .expect("cancelled typed turn");
-        worker.join().expect("cancelled worker");
         assert!(matches!(
             cancelled,
             TuiHostedOperationOutcome::Turn { status } if status == "cancelled"

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -45,8 +45,8 @@ node --test scripts/test-validate-runtime-surface-contract.mjs
 node scripts/validate-runtime-surface-contract.mjs
 node --test scripts/test-validate-windows-platform-boundaries.mjs
 node scripts/validate-windows-platform-boundaries.mjs
-cargo nextest run -p orca-tui --lib --locked --profile ci-serial
-cargo nextest run --workspace --all-targets --locked --profile ci --no-fail-fast
+cargo nextest run -p orca-tui --lib --locked --profile ci-serial --retries 0
+cargo nextest run --workspace --all-targets --locked --profile ci --no-fail-fast --retries 0
 node scripts/release/test-verify-version-sync.mjs
 node scripts/release/test-stage-npm.mjs
 node scripts/release/test-verify-published.mjs
@@ -65,9 +65,10 @@ For a tag-triggered release, `release.yml` verifies that the tagged commit is
 the current `origin/main` commit and that the Linux `linux-full` check plus the
 Windows `native-x64` and `native-arm64` checks already succeeded for that exact
 SHA. These PR/main checks retain the complete runtime, subprocess, SQLite,
-filesystem, and platform coverage. The tag workflow reuses that evidence
-instead of rerunning the same full suites. A manual `workflow_dispatch` remains
-the full release dry-run path and executes every gate above.
+filesystem, and platform coverage with framework retries disabled. The tag
+workflow reuses that evidence instead of rerunning the same full suites. A
+manual `workflow_dispatch` remains the full release dry-run path and executes
+every gate above with framework retries disabled.
 
 ### 5. Update the website
 

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -62,11 +62,12 @@ failures; do not hide them with a global allow, and do not turn a patch release
 into an unrelated public-API cleanup merely to satisfy a newer toolchain lint.
 
 For a tag-triggered release, `release.yml` verifies that the tagged commit is
-the current `origin/main` commit and that the `Runtime Surface Contract`
-`validate` check plus the Windows `native-x64` and `native-arm64` checks already
-succeeded for that exact SHA. It then reuses that evidence instead of rerunning
-the same full suites. A manual `workflow_dispatch` remains the full release
-dry-run path and executes every gate above.
+the current `origin/main` commit and that the Linux `linux-full` check plus the
+Windows `native-x64` and `native-arm64` checks already succeeded for that exact
+SHA. These PR/main checks retain the complete runtime, subprocess, SQLite,
+filesystem, and platform coverage. The tag workflow reuses that evidence
+instead of rerunning the same full suites. A manual `workflow_dispatch` remains
+the full release dry-run path and executes every gate above.
 
 ### 5. Update the website
 
@@ -98,7 +99,7 @@ git push -u origin <release-branch>
 # open the pull request, wait for required Linux and Windows checks, then merge
 git switch main
 git pull --ff-only origin main
-git tag vX.Y.Z
+git tag -a vX.Y.Z -F docs/releases/vX.Y.Z.md
 git push origin vX.Y.Z
 ```
 

--- a/docs/releases/v0.4.30.md
+++ b/docs/releases/v0.4.30.md
@@ -1,0 +1,39 @@
+# Orca v0.4.30
+
+Faster release promotion and deterministic Windows validation.
+
+## Changes
+
+- Makes typed TUI activation tests wait on the controller's state-change
+  notification instead of depending on a two-second polling race.
+- Builds background terminal completion proofs from the latest authoritative
+  surface snapshot, preserving tool receipts when approval denial and provider
+  completion overlap.
+- Keeps the complete Linux, Windows x64, and Windows ARM64 test coverage on
+  pull requests and `main`, while tag releases verify those successful checks
+  for the exact commit instead of rerunning the same suites.
+- Keeps manual Release workflow dispatches as the full end-to-end dry-run path.
+
+## Compatibility
+
+No user-facing API, configuration, or persistence format changes.
+
+## Verification
+
+```bash
+node scripts/test-validate-runtime-surface-contract.mjs
+node scripts/validate-runtime-surface-contract.mjs
+node scripts/test-validate-windows-platform-boundaries.mjs
+node scripts/validate-windows-platform-boundaries.mjs
+cargo nextest run -p orca-tui --lib --locked --profile ci-serial
+cargo nextest run --workspace --all-targets --locked --profile ci --no-fail-fast
+npm --prefix site run build
+npm --prefix site run check:seo
+```
+
+## Upgrade
+
+```bash
+npm install -g @blade-ai/orca@0.4.30
+orca --version
+```

--- a/docs/releases/v0.4.30.md
+++ b/docs/releases/v0.4.30.md
@@ -15,7 +15,8 @@ Faster release promotion and deterministic Windows validation.
 - Keeps the complete Linux, Windows x64, and Windows ARM64 test coverage on
   pull requests and `main`, while tag releases verify those successful checks
   for the exact commit instead of rerunning the same suites.
-- Keeps manual Release workflow dispatches as the full end-to-end dry-run path.
+- Enforces zero framework retries on every full CI suite, and keeps manual
+  Release workflow dispatches as the full end-to-end dry-run path.
 
 ## Compatibility
 
@@ -29,8 +30,8 @@ node scripts/validate-runtime-surface-contract.mjs
 node scripts/test-validate-windows-platform-boundaries.mjs
 node scripts/validate-windows-platform-boundaries.mjs
 cargo test -p orca-platform --test atomic_file_contract --locked
-cargo nextest run -p orca-tui --lib --locked --profile ci-serial
-cargo nextest run --workspace --all-targets --locked --profile ci --no-fail-fast
+cargo nextest run -p orca-tui --lib --locked --profile ci-serial --retries 0
+cargo nextest run --workspace --all-targets --locked --profile ci --no-fail-fast --retries 0
 npm --prefix site run build
 npm --prefix site run check:seo
 ```

--- a/docs/releases/v0.4.30.md
+++ b/docs/releases/v0.4.30.md
@@ -9,6 +9,9 @@ Faster release promotion and deterministic Windows validation.
 - Builds background terminal completion proofs from the latest authoritative
   surface snapshot, preserving tool receipts when approval denial and provider
   completion overlap.
+- Retries the transient Windows `ReplaceFileW` collision raised when workflow
+  workers and control commands atomically update the same persisted run state,
+  with a real cross-process filesystem contract covering the race.
 - Keeps the complete Linux, Windows x64, and Windows ARM64 test coverage on
   pull requests and `main`, while tag releases verify those successful checks
   for the exact commit instead of rerunning the same suites.
@@ -25,6 +28,7 @@ node scripts/test-validate-runtime-surface-contract.mjs
 node scripts/validate-runtime-surface-contract.mjs
 node scripts/test-validate-windows-platform-boundaries.mjs
 node scripts/validate-windows-platform-boundaries.mjs
+cargo test -p orca-platform --test atomic_file_contract --locked
 cargo nextest run -p orca-tui --lib --locked --profile ci-serial
 cargo nextest run --workspace --all-targets --locked --profile ci --no-fail-fast
 npm --prefix site run build

--- a/docs/releases/v0.4.30.md
+++ b/docs/releases/v0.4.30.md
@@ -6,6 +6,8 @@ Faster release promotion and deterministic Windows validation.
 
 - Makes typed TUI activation tests wait on the controller's state-change
   notification instead of depending on a two-second polling race.
+- Persists an active Goal's paused state before shutdown exposes cancellation
+  to the running generation.
 - Builds background terminal completion proofs from the latest authoritative
   surface snapshot, preserving tool receipts when approval denial and provider
   completion overlap.

--- a/docs/releases/v0.4.30.md
+++ b/docs/releases/v0.4.30.md
@@ -25,10 +25,15 @@ No user-facing API, configuration, or persistence format changes.
 ## Verification
 
 ```bash
+cargo fmt --all -- --check
+cargo check --locked
+cargo clippy --workspace --all-targets --locked -j 1
 node scripts/test-validate-runtime-surface-contract.mjs
 node scripts/validate-runtime-surface-contract.mjs
 node scripts/test-validate-windows-platform-boundaries.mjs
 node scripts/validate-windows-platform-boundaries.mjs
+node scripts/release/test-verify-version-sync.mjs
+node scripts/release/verify-version-sync.mjs
 cargo test -p orca-platform --test atomic_file_contract --locked
 cargo nextest run -p orca-tui --lib --locked --profile ci-serial --retries 0
 cargo nextest run --workspace --all-targets --locked --profile ci --no-fail-fast --retries 0

--- a/docs/releases/v0.4.30.md
+++ b/docs/releases/v0.4.30.md
@@ -9,9 +9,9 @@ Faster release promotion and deterministic Windows validation.
 - Builds background terminal completion proofs from the latest authoritative
   surface snapshot, preserving tool receipts when approval denial and provider
   completion overlap.
-- Retries the transient Windows `ReplaceFileW` collision raised when workflow
-  workers and control commands atomically update the same persisted run state,
-  with a real cross-process filesystem contract covering the race.
+- Serializes workflow state and control updates across processes and retries
+  safe transient Windows `ReplaceFileW` collisions, with a real cross-process
+  filesystem contract covering the race.
 - Keeps the complete Linux, Windows x64, and Windows ARM64 test coverage on
   pull requests and `main`, while tag releases verify those successful checks
   for the exact commit instead of rerunning the same suites.

--- a/npm/orca/package.json
+++ b/npm/orca/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@blade-ai/orca",
-  "version": "0.4.29",
+  "version": "0.4.30",
   "description": "Orca CLI: a DeepSeek-native coding agent.",
   "homepage": "https://orcaagent.dev/",
   "license": "MIT",

--- a/scripts/test-validate-windows-platform-boundaries.mjs
+++ b/scripts/test-validate-windows-platform-boundaries.mjs
@@ -819,6 +819,20 @@ for (const marker of [
     `task persistence and recovered workers must contain ${marker}`,
   );
 }
+const workflowStateSource = readNormalizedSource(
+  "crates/orca-runtime/src/workflow/state.rs",
+);
+for (const marker of [
+  "ExclusiveFileLock",
+  'join("run-state.lock")',
+  "with_run_mutation_lock",
+  "write_state_unlocked",
+]) {
+  assert.ok(
+    workflowStateSource.includes(marker),
+    `workflow state and control mutations must share the cross-process run lock: ${marker}`,
+  );
+}
 const providerSource = readNormalizedSource(
   "crates/orca-provider/src/lib.rs",
 );

--- a/scripts/test-validate-windows-platform-boundaries.mjs
+++ b/scripts/test-validate-windows-platform-boundaries.mjs
@@ -595,11 +595,18 @@ assert.ok(existsSync(linuxWorkflowPath), "Linux CI workflow must exist");
 const linuxWorkflow = normalizeLineEndings(
   readFileSync(linuxWorkflowPath, "utf8"),
 );
+const pinnedNextestAction =
+  "taiki-e/install-action@4dc1969decfa71b34f25aa7f3dd4656654d9ad1e";
 for (const [source, label] of [
   [workflow, "Windows CI"],
   [linuxWorkflow, "Linux CI"],
   [releaseWorkflow, "Release dry-run"],
 ]) {
+  assert.ok(
+    source.includes(pinnedNextestAction) &&
+      !source.includes("taiki-e/install-action@nextest"),
+    `${label} must pin the nextest installer to the reviewed commit`,
+  );
   const nextestCommands = source
     .split("\n")
     .filter((line) => line.includes("cargo nextest run"));
@@ -672,7 +679,7 @@ for (const marker of [
   "  linux-full:",
   "runs-on: ubuntu-22.04",
   "timeout-minutes: 90",
-  "taiki-e/install-action@nextest",
+  pinnedNextestAction,
   "sudo apt-get install -y ripgrep bubblewrap",
   "python3 -m unittest discover -s terminal_bench -p 'test_*.py' -v",
   "node scripts/test-repository-hygiene.mjs",
@@ -702,7 +709,7 @@ for (const marker of [
   "node scripts/test-validate-windows-platform-boundaries.mjs",
   "cargo check --workspace --all-targets --locked",
   "cargo clippy --workspace --all-targets --locked",
-  "taiki-e/install-action@nextest",
+  pinnedNextestAction,
   "cargo nextest run -p orca-tui --lib --locked --profile ci-serial",
   "cargo nextest run --test tui_pty_contract --locked --profile ci-serial --no-tests=pass",
   "cargo nextest run --workspace --all-targets --locked --profile ci --no-fail-fast",

--- a/scripts/test-validate-windows-platform-boundaries.mjs
+++ b/scripts/test-validate-windows-platform-boundaries.mjs
@@ -595,6 +595,22 @@ assert.ok(existsSync(linuxWorkflowPath), "Linux CI workflow must exist");
 const linuxWorkflow = normalizeLineEndings(
   readFileSync(linuxWorkflowPath, "utf8"),
 );
+for (const [source, label] of [
+  [workflow, "Windows CI"],
+  [linuxWorkflow, "Linux CI"],
+  [releaseWorkflow, "Release dry-run"],
+]) {
+  const nextestCommands = source
+    .split("\n")
+    .filter((line) => line.includes("cargo nextest run"));
+  assert.ok(nextestCommands.length > 0, `${label} must run nextest`);
+  for (const command of nextestCommands) {
+    assert.ok(
+      command.includes("--retries 0"),
+      `${label} nextest commands must disable framework retries: ${command.trim()}`,
+    );
+  }
+}
 const installerSource = readFileSync(path.join(repoRoot, "install.ps1"), "utf8");
 const pullRequest = workflow.match(/  pull_request:\n([\s\S]*?)\n  push:/);
 assert.ok(pullRequest, "Windows CI must validate pull requests before merge");
@@ -991,6 +1007,17 @@ for (const gate of [releaseWindowsX64Gate[0], releaseWindowsArm64Gate[0]]) {
       gate.includes("$PSNativeCommandUseErrorActionPreference = $true"),
     "release Windows behavior gates must fail on every native command error",
   );
+  for (const marker of [
+    "cargo build -p orca-windows-runner --locked",
+    "cargo nextest run -p orca-tui --lib --locked --profile ci-serial --retries 0",
+    "cargo nextest run --test tui_pty_contract --locked --profile ci-serial --no-tests=pass --retries 0",
+    "cargo nextest run --workspace --all-targets --locked --profile ci --no-fail-fast --retries 0",
+  ]) {
+    assert.ok(
+      gate.includes(marker),
+      `release Windows behavior gates must retain the zero-retry full suite: ${marker}`,
+    );
+  }
 }
 for (const marker of [
   "prompt_names_powershell_7_as_the_active_shell_dialect",

--- a/scripts/test-validate-windows-platform-boundaries.mjs
+++ b/scripts/test-validate-windows-platform-boundaries.mjs
@@ -587,6 +587,14 @@ const workflow = normalizeLineEndings(readFileSync(workflowPath, "utf8"));
 const releaseWorkflowPath = path.join(repoRoot, ".github/workflows/release.yml");
 assert.ok(existsSync(releaseWorkflowPath), "release workflow must exist");
 const releaseWorkflow = normalizeLineEndings(readFileSync(releaseWorkflowPath, "utf8"));
+const linuxWorkflowPath = path.join(
+  repoRoot,
+  ".github/workflows/runtime-contract.yml",
+);
+assert.ok(existsSync(linuxWorkflowPath), "Linux CI workflow must exist");
+const linuxWorkflow = normalizeLineEndings(
+  readFileSync(linuxWorkflowPath, "utf8"),
+);
 const installerSource = readFileSync(path.join(repoRoot, "install.ps1"), "utf8");
 const pullRequest = workflow.match(/  pull_request:\n([\s\S]*?)\n  push:/);
 assert.ok(pullRequest, "Windows CI must validate pull requests before merge");
@@ -614,6 +622,58 @@ for (const marker of [
   assert.ok(
     push[1].includes(marker),
     `Windows push trigger must contain ${marker}`,
+  );
+}
+const linuxPullRequest = linuxWorkflow.match(
+  /  pull_request:\n([\s\S]*?)\n  push:/,
+);
+assert.ok(linuxPullRequest, "Linux CI must validate pull requests before merge");
+const linuxPush = linuxWorkflow.match(/  push:\n([\s\S]*?)\n\npermissions:/);
+assert.ok(linuxPush, "Linux CI must validate relevant main-branch pushes");
+for (const trigger of [linuxPullRequest[1], linuxPush[1]]) {
+  for (const marker of [
+    "branches: [main]",
+    '"Cargo.toml"',
+    '"Cargo.lock"',
+    '"src/**"',
+    '"crates/**"',
+    '"tests/**"',
+    '"terminal_bench/**"',
+    '"scripts/**"',
+    '".config/nextest.toml"',
+    '".github/workflows/release.yml"',
+    '".github/workflows/runtime-contract.yml"',
+    '".github/workflows/windows-ci.yml"',
+  ]) {
+    assert.ok(
+      trigger.includes(marker),
+      `Linux PR/main trigger must contain ${marker}`,
+    );
+  }
+}
+for (const marker of [
+  "name: Linux",
+  "  linux-full:",
+  "runs-on: ubuntu-22.04",
+  "timeout-minutes: 90",
+  "taiki-e/install-action@nextest",
+  "sudo apt-get install -y ripgrep bubblewrap",
+  "python3 -m unittest discover -s terminal_bench -p 'test_*.py' -v",
+  "node scripts/test-repository-hygiene.mjs",
+  "cargo nextest run -p orca-tui --lib --locked --profile ci-serial",
+  "cargo nextest run --test tui_pty_contract --locked --profile ci-serial",
+  "cargo clippy --workspace --all-targets --locked -j 1",
+  "cargo nextest run --workspace --all-targets --locked --profile ci --no-fail-fast",
+  "generation_stop_terminal_mapping_preserves_not_started_reasons",
+  "surface_goal_terminal_checkpoint_failure_recovers_exact_verified_batch",
+  "cargo test -p orca-runtime --test runtime_host",
+  "cargo test -p orca-runtime --test subagent_observability_contract",
+  "cargo test -p orca-runtime --test runtime_surface_interaction",
+  "cargo test --test subagent_contract",
+]) {
+  assert.ok(
+    linuxWorkflow.includes(marker),
+    `Linux full CI workflow must contain ${marker}`,
   );
 }
 for (const marker of [
@@ -951,9 +1011,15 @@ for (const marker of [
 assert.ok(
   releaseWorkflow.includes("- name: Verify tagged commit passed main gates") &&
     releaseWorkflow.includes("checks: read") &&
+    releaseWorkflow.includes("actions: read") &&
     releaseWorkflow.includes('test "$(git rev-parse origin/main)" = "$GITHUB_SHA"') &&
-    releaseWorkflow.includes("for name in validate native-x64 native-arm64") &&
-    releaseWorkflow.includes('.app.slug == "github-actions"'),
+    releaseWorkflow.includes("check-runs?per_page=100") &&
+    releaseWorkflow.includes("for name in linux-full native-x64 native-arm64") &&
+    releaseWorkflow.includes('.app.slug == "github-actions"') &&
+    releaseWorkflow.includes('-f head_sha="$GITHUB_SHA"') &&
+    releaseWorkflow.includes("-f event=push") &&
+    releaseWorkflow.includes("for workflow in Linux Windows") &&
+    releaseWorkflow.includes('.event == "push"'),
   "tag releases must verify successful main checks for the exact tagged commit",
 );
 for (const marker of [

--- a/site/public/sitemap.xml
+++ b/site/public/sitemap.xml
@@ -2,37 +2,37 @@
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
     <loc>https://orcaagent.dev/</loc>
-    <lastmod>2026-09-11</lastmod>
+    <lastmod>2026-09-12</lastmod>
     <changefreq>weekly</changefreq>
     <priority>1.0</priority>
   </url>
   <url>
     <loc>https://orcaagent.dev/changelog/</loc>
-    <lastmod>2026-09-11</lastmod>
+    <lastmod>2026-09-12</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://orcaagent.dev/terminal-coding-agent/</loc>
-    <lastmod>2026-09-11</lastmod>
+    <lastmod>2026-09-12</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://orcaagent.dev/deepseek-coding-agent/</loc>
-    <lastmod>2026-09-11</lastmod>
+    <lastmod>2026-09-12</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://orcaagent.dev/github/</loc>
-    <lastmod>2026-09-11</lastmod>
+    <lastmod>2026-09-12</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.75</priority>
   </url>
   <url>
     <loc>https://orcaagent.dev/mcp/</loc>
-    <lastmod>2026-09-11</lastmod>
+    <lastmod>2026-09-12</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.75</priority>
   </url>

--- a/site/src/changelog/Changelog.tsx
+++ b/site/src/changelog/Changelog.tsx
@@ -78,6 +78,8 @@ const copy = {
       ],
     },
     summaries: {
+      "v0.4.30":
+        "Makes release promotion reuse successful checks from the exact main commit while preserving full pull-request and main coverage. It also removes Windows timing races from TUI activation and background terminal proof generation.",
       "v0.4.29":
         "Adds structured inline questionnaires, persistent model and reasoning preferences, and confirmed Full Access transitions that update the active task at the next tool boundary while preserving already-running work. It also isolates the multi-process workflow cancellation contract for deterministic release validation.",
       "v0.4.27":
@@ -668,6 +670,8 @@ const copy = {
       ],
     },
     summaries: {
+      "v0.4.30":
+        "发布流程复用同一 main 提交已通过的完整检查，同时保留 PR 与 main 的全量跨平台覆盖；并修复 TUI 激活等待及后台终态证明生成中的 Windows 时序竞争。",
       "v0.4.29":
         "新增结构化内联问卷与模型、推理强度持久化；Full Access 经二次确认后从当前任务的下一次工具准入生效，同时保持已运行工具和既有子代理的权限快照不变；发布门禁同时隔离多进程 workflow cancellation 契约，避免并发调度造成非确定性超时。",
       "v0.4.27":

--- a/site/src/changelog/Changelog.tsx
+++ b/site/src/changelog/Changelog.tsx
@@ -1,14 +1,14 @@
 import { useEffect, useState } from "react";
 import {
-  type Locale,
-  type SeoEntry,
-  applySeoHead,
-  canonicalOrigin,
-  detectInitialLocale,
-  links,
-  localeStorageKey,
-  releaseVersion,
-  releases,
+    type Locale,
+    type SeoEntry,
+    applySeoHead,
+    canonicalOrigin,
+    detectInitialLocale,
+    links,
+    localeStorageKey,
+    releaseVersion,
+    releases,
 } from "../shared";
 
 const canonicalUrl = `${canonicalOrigin}/changelog/`;
@@ -79,7 +79,7 @@ const copy = {
     },
     summaries: {
       "v0.4.30":
-        "Makes release promotion reuse successful checks from the exact main commit while preserving full pull-request and main coverage. It also removes Windows timing races from TUI activation and background terminal proof generation.",
+        "Makes release promotion reuse successful checks from the exact main commit while preserving full pull-request and main coverage. It also removes Windows races from TUI activation, background terminal proof generation, and cross-process workflow state replacement.",
       "v0.4.29":
         "Adds structured inline questionnaires, persistent model and reasoning preferences, and confirmed Full Access transitions that update the active task at the next tool boundary while preserving already-running work. It also isolates the multi-process workflow cancellation contract for deterministic release validation.",
       "v0.4.27":
@@ -671,7 +671,7 @@ const copy = {
     },
     summaries: {
       "v0.4.30":
-        "发布流程复用同一 main 提交已通过的完整检查，同时保留 PR 与 main 的全量跨平台覆盖；并修复 TUI 激活等待及后台终态证明生成中的 Windows 时序竞争。",
+        "发布流程复用同一 main 提交已通过的完整检查，同时保留 PR 与 main 的全量跨平台覆盖；并修复 TUI 激活等待、后台终态证明生成及跨进程 workflow 状态替换中的 Windows 竞争。",
       "v0.4.29":
         "新增结构化内联问卷与模型、推理强度持久化；Full Access 经二次确认后从当前任务的下一次工具准入生效，同时保持已运行工具和既有子代理的权限快照不变；发布门禁同时隔离多进程 workflow cancellation 契约，避免并发调度造成非确定性超时。",
       "v0.4.27":

--- a/site/src/shared.ts
+++ b/site/src/shared.ts
@@ -4,9 +4,16 @@ export const localeStorageKey = "orca-site-locale";
 export const canonicalOrigin = "https://orcaagent.dev";
 export const socialImageUrl = `${canonicalOrigin}/orca-social.png`;
 
-export const releaseVersion = "v0.4.29";
+export const releaseVersion = "v0.4.30";
 
 export const releases = [
+  {
+    version: "v0.4.30",
+    date: "2026-09-12",
+    title: "Faster, deterministic releases",
+    body: "Preserves full cross-platform coverage while promoting already-verified main commits, and removes timing races from TUI activation and background terminal proof handling.",
+    url: "https://github.com/echoVic/orca-agent/releases/tag/v0.4.30",
+  },
   {
     version: "v0.4.29",
     date: "2026-09-11",

--- a/site/src/shared.ts
+++ b/site/src/shared.ts
@@ -11,7 +11,7 @@ export const releases = [
     version: "v0.4.30",
     date: "2026-09-12",
     title: "Faster, deterministic releases",
-    body: "Preserves full cross-platform coverage while promoting already-verified main commits, and removes timing races from TUI activation and background terminal proof handling.",
+    body: "Preserves full cross-platform coverage while promoting already-verified main commits, and removes Windows races from TUI activation, background terminal proofs, and cross-process workflow state replacement.",
     url: "https://github.com/echoVic/orca-agent/releases/tag/v0.4.30",
   },
   {


### PR DESCRIPTION
## Summary

- bump Orca and npm package versions to `0.4.30` and update release/site documentation
- fix deterministic TUI activation and authoritative background terminal proof receipts
- serialize persisted workflow state/control mutations across processes and safely retry Windows replacement races
- replace a busy-loop continuation assertion with an exact checkpoint-failure notification
- run complete Linux, Windows x64, and Windows ARM64 suites on PR/main with `--retries 0`; tag releases promote only an exact successful main SHA

## Verification

- `cargo fmt --all -- --check`
- `cargo test -p orca-platform --test atomic_file_contract --locked`
- `cargo nextest run -p orca-runtime prepared_surface_goal_continuation_recovers_without_reexecuting_successor --locked --retries 0 --stress-count 20 -j 2`
- `cargo nextest run -p orca-runtime workflow_agent_delay_observes_pause_and_resume_requests --locked --retries 0 --stress-count 10 -j 2`
- `cargo check -p orca-runtime --tests --locked`
- `cargo clippy -p orca-platform --all-targets --locked`
- `node scripts/test-validate-windows-platform-boundaries.mjs`
- `node scripts/validate-windows-platform-boundaries.mjs`
- `node scripts/release/verify-version-sync.mjs`
- `npm --prefix site run build`
- `npm --prefix site run check:seo`

The authoritative zero-retry Linux and Windows x64/ARM64 checks are running on commit `3ef0b0f5`.